### PR TITLE
Ignore source if getting fails

### DIFF
--- a/custom_components/samsung_soundbar/media_player.py
+++ b/custom_components/samsung_soundbar/media_player.py
@@ -291,14 +291,17 @@ class MultiRoomDevice(MediaPlayerEntity):
         self._state = STATE_ON
         "Get Current Source"
         source = await self.api.get_source()
-        "Source 0 is type on input"
-        if source[0]:
-          self._current_source = source[0]
-        "Source 1 is input mode"
-        if source[1]:
-          self._mode = source[1]
+        if source is not None:
+          "Source 0 is type on input"
+          if source[0]:
+            self._current_source = source[0]
+          "Source 1 is input mode"
+          if source[1]:
+            self._mode = source[1]
+          else:
+            self._mode = ''
         else:
-          self._mode = ''
+            self._mode = ''
         "Get Volume"
         volume = await self.api.get_volume()
         if volume[0]:

--- a/custom_components/samsung_soundbar/media_player.py
+++ b/custom_components/samsung_soundbar/media_player.py
@@ -302,10 +302,13 @@ class MultiRoomDevice(MediaPlayerEntity):
             self._mode = ''
         else:
             self._mode = ''
-        "Get Volume"
-        volume = await self.api.get_volume()
-        if volume[0]:
-          self._volume = int(volume[0]) / self._max_volume
+        try:
+          "Get Volume"
+          volume = await self.api.get_volume()
+          if volume[0]:
+            self._volume = int(volume[0]) / self._max_volume
+        except:
+          _LOGGER.error("Failed to get volume")
         "Get Mute State"
         muted = await self.api.get_muted()
         if muted:


### PR DESCRIPTION
On some devices/firmware versions, getting the source seems to fail currently.
This at least allows the user to continue to use the device in other ways as everything
else seems to work fine.

I've got a Q90R on the latest firmware using HDMI ARC and for whatever reason this get source function fails.

still looking into why, but this at least makes this pretty much completely functional otherwise. 