### PR TITLE
Fix for upcoming error in 2022.2

### DIFF
--- a/custom_components/samsung_soundbar/media_player.py
+++ b/custom_components/samsung_soundbar/media_player.py
@@ -86,7 +86,7 @@ class MultiRoomApi():
     url = '{0}/{1}?{2}'.format(self.endpoint, mode, query)
 
     try:
-      with async_timeout.timeout(TIMEOUT, loop=self.hass.loop):
+      with async_timeout.timeout(TIMEOUT):
         _LOGGER.debug("Executing: {} with cmd: {}".format(url, cmd))
         response = await self.session.get(url)
         data = await response.text()


### PR DESCRIPTION
In 2022.2 the loop keyword argument will be depreciated. This proposed change fixes that.