### PR TITLE
fix: import missing `STATE_PLAYING`

### DIFF
--- a/custom_components/samsung_soundbar/media_player.py
+++ b/custom_components/samsung_soundbar/media_player.py
@@ -33,6 +33,7 @@ from homeassistant.const import (
   CONF_NAME,
   CONF_HOST,
   STATE_IDLE,
+  STATE_PLAYING,
   STATE_ON,
   STATE_OFF
 )


### PR DESCRIPTION
When running with `power_options: False`
```yaml
media_player:
  - platform: samsung_soundbar
    name: "Soundbar"
    host: 192.168.1.1
    port: 55001
    power_options: False
```

this code get called and fail because `STATE_PLAYING` was not imported: https://github.com/IDmedia/hass-samsung_soundbar/blob/e8b435f634767d2967c55c201831b900be6d3653/custom_components/samsung_soundbar/media_player.py#L339
