### PR TITLE
Add AUX as possible source

### DIFF
--- a/custom_components/samsung_soundbar/media_player.py
+++ b/custom_components/samsung_soundbar/media_player.py
@@ -43,7 +43,8 @@ MULTI_ROOM_SOURCE_TYPE = [
   'hdmi2',
   'optical',
   'bt',
-  'wifi'
+  'wifi',
+  'aux'
 ]
 
 DEFAULT_NAME = 'Samsung Soundbar'


### PR DESCRIPTION
Added `'aux'` as a possible source.
Tested this by changing it first locally on my system. Works like a charm on the HW-M650.

I have a voice satellite connected to the AUX port now, so I'd like to switch to AUX when the voice satellite is being used.