### PR TITLE
Add UI config flow

### DIFF
--- a/custom_components/samsung_soundbar/__init__.py
+++ b/custom_components/samsung_soundbar/__init__.py
@@ -1,0 +1,15 @@
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+PLATFORMS = ["media_player"]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+  """Set up Samsung Soundbar from a config entry."""
+  await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+  return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+  """Unload a config entry."""
+  return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/custom_components/samsung_soundbar/config_flow.py
+++ b/custom_components/samsung_soundbar/config_flow.py
@@ -1,0 +1,64 @@
+import voluptuous as vol
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.selector import (
+  NumberSelector,
+  NumberSelectorConfig,
+  NumberSelectorMode,
+)
+
+from .const import (
+  DOMAIN,
+  DEFAULT_NAME,
+  DEFAULT_PORT,
+  DEFAULT_MAX_VOLUME,
+  DEFAULT_POWER_OPTIONS,
+  CONF_PORT,
+  CONF_MAX_VOLUME,
+  CONF_POWER_OPTIONS,
+)
+from .media_player import MultiRoomApi
+
+
+class SamsungSoundbarConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+  """Handle a config flow for Samsung Soundbar."""
+
+  VERSION = 1
+
+  async def async_step_user(self, user_input=None):
+    """Handle the initial step."""
+    errors = {}
+
+    if user_input is not None:
+      host = user_input[CONF_HOST]
+      port = user_input.get(CONF_PORT, DEFAULT_PORT)
+      session = async_get_clientsession(self.hass)
+      api = MultiRoomApi(host, port, session, self.hass)
+
+      # Basic connectivity test
+      speaker_name = await api.get_speaker_name()
+
+      if speaker_name:
+        await self.async_set_unique_id(f"{host}:{port}")
+        self._abort_if_unique_id_configured()
+        return self.async_create_entry(
+          title=user_input.get(CONF_NAME, DEFAULT_NAME),
+          data=user_input,
+        )
+      errors["base"] = "cannot_connect"
+
+    return self.async_show_form(
+      step_id="user",
+      data_schema=vol.Schema({
+        vol.Required(CONF_HOST): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.string,
+        vol.Required(CONF_MAX_VOLUME, default=int(DEFAULT_MAX_VOLUME)): NumberSelector(
+          NumberSelectorConfig(min=0, max=100, step=1, mode=NumberSelectorMode.SLIDER)
+        ),
+        vol.Required(CONF_POWER_OPTIONS, default=DEFAULT_POWER_OPTIONS): cv.boolean,
+      }),
+      errors=errors,
+    )

--- a/custom_components/samsung_soundbar/config_flow.py
+++ b/custom_components/samsung_soundbar/config_flow.py
@@ -1,5 +1,7 @@
 import voluptuous as vol
+from urllib.parse import urlparse
 from homeassistant import config_entries
+from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
 from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -61,4 +63,45 @@ class SamsungSoundbarConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         vol.Required(CONF_POWER_OPTIONS, default=DEFAULT_POWER_OPTIONS): cv.boolean,
       }),
       errors=errors,
+    )
+
+  async def async_step_ssdp(self, discovery_info: SsdpServiceInfo):
+    """Handle SSDP discovery."""
+    host = urlparse(discovery_info.ssdp_location).hostname
+    port = DEFAULT_PORT
+    session = async_get_clientsession(self.hass)
+    api = MultiRoomApi(host, port, session, self.hass)
+
+    speaker_name = await api.get_speaker_name()
+    if not speaker_name:
+      return self.async_abort(reason="not_samsung_soundbar")
+
+    await self.async_set_unique_id(f"{host}:{port}")
+    self._abort_if_unique_id_configured()
+
+    self._discovered_host = host
+    self._discovered_name = speaker_name[0] if isinstance(speaker_name, list) else speaker_name
+    self.context["title_placeholders"] = {"name": self._discovered_name}
+    return await self.async_step_confirm()
+
+  async def async_step_confirm(self, user_input=None):
+    """Confirm adding a discovered device."""
+    if user_input is not None:
+      return self.async_create_entry(
+        title=self._discovered_name,
+        data={
+          CONF_HOST: self._discovered_host,
+          CONF_NAME: self._discovered_name,
+          CONF_PORT: DEFAULT_PORT,
+          CONF_MAX_VOLUME: int(DEFAULT_MAX_VOLUME),
+          CONF_POWER_OPTIONS: DEFAULT_POWER_OPTIONS,
+        },
+      )
+
+    return self.async_show_form(
+      step_id="confirm",
+      description_placeholders={
+        "name": self._discovered_name,
+        "host": self._discovered_host,
+      },
     )

--- a/custom_components/samsung_soundbar/const.py
+++ b/custom_components/samsung_soundbar/const.py
@@ -1,0 +1,24 @@
+DOMAIN = "samsung_soundbar"
+
+CONF_PORT = 'port'
+CONF_MAX_VOLUME = 'max_volume'
+CONF_POWER_OPTIONS = 'power_options'
+
+DEFAULT_NAME = 'Samsung Soundbar'
+DEFAULT_PORT = '56001'
+DEFAULT_POWER_OPTIONS = True
+DEFAULT_MAX_VOLUME = '40'
+
+BOOL_OFF = 'off'
+BOOL_ON = 'on'
+TIMEOUT = 2
+
+MULTI_ROOM_SOURCE_TYPE = [
+    'digital',
+    'hdmi1',
+    'hdmi2',
+    'optical',
+    'bt',
+    'aux',
+    'wifi',
+]

--- a/custom_components/samsung_soundbar/manifest.json
+++ b/custom_components/samsung_soundbar/manifest.json
@@ -2,12 +2,12 @@
   "domain": "samsung_soundbar",
   "name": "Samsung Soundbar",
   "documentation": "https://github.com/IDmedia/hass-samsung_soundbar",
-  "dependencies": ["http"],
-  "version": "1.0.1",
+  "version": "1.1.0",
   "codeowners": [
     "@IDmedia"
   ],
   "requirements": [
     "xmltodict==0.11.0"
-  ]
+  ],
+  "config_flow": true
 }

--- a/custom_components/samsung_soundbar/manifest.json
+++ b/custom_components/samsung_soundbar/manifest.json
@@ -9,5 +9,14 @@
   "requirements": [
     "xmltodict==0.11.0"
   ],
-  "config_flow": true
+  "config_flow": true,
+  "ssdp": [
+    {
+      "st": "urn:schemas-upnp-org:device:MediaRenderer:1",
+      "manufacturer": "Samsung Electronics"
+    },
+    {
+      "st": "urn:samsung.com:device:RemoteControlReceiver:1"
+    }
+  ]
 }

--- a/custom_components/samsung_soundbar/media_player.py
+++ b/custom_components/samsung_soundbar/media_player.py
@@ -12,10 +12,6 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 _LOGGER = logging.getLogger(__name__)
 
-VERSION = '1.0.0'
-
-DOMAIN = "samsung_soundbar"
-
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=3)
 MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(seconds=3)
 
@@ -37,35 +33,25 @@ from homeassistant.const import (
   STATE_OFF
 )
 
-MULTI_ROOM_SOURCE_TYPE = [
-  'digital',
-  'hdmi1',
-  'hdmi2',
-  'optical',
-  'bt',
-  'aux',
-  'wifi'
-]
+from .const import (
+  DEFAULT_NAME,
+  DEFAULT_PORT,
+  DEFAULT_MAX_VOLUME,
+  DEFAULT_POWER_OPTIONS,
+  BOOL_OFF,
+  BOOL_ON,
+  TIMEOUT,
+  MULTI_ROOM_SOURCE_TYPE,
+  CONF_PORT,
+  CONF_MAX_VOLUME,
+  CONF_POWER_OPTIONS,
+)
 
-DEFAULT_NAME = 'Samsung Soundbar'
-DEFAULT_PORT = '56001'
-DEFAULT_POWER_OPTIONS = True
-DEFAULT_MAX_VOLUME = '40'
-BOOL_OFF = 'off'
-BOOL_ON = 'on'
-TIMEOUT = 2
 SUPPORT_SAMSUNG_MULTI_ROOM = (
   MediaPlayerEntityFeature.VOLUME_SET
   | MediaPlayerEntityFeature.VOLUME_MUTE
   | MediaPlayerEntityFeature.SELECT_SOURCE
 )
-
-
-MediaPlayerEntityFeature
-
-CONF_MAX_VOLUME = 'max_volume'
-CONF_PORT = 'port'
-CONF_POWER_OPTIONS = 'power_options'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
   vol.Required(CONF_HOST, default='127.0.0.1'): cv.string,
@@ -340,7 +326,7 @@ class MultiRoomDevice(MediaPlayerEntity):
       source = await self.api.get_source()
       if source:
         self._current_source = source[0]
-        self._state = STATE_PLAYING
+        self._state = STATE_ON
       else:
         self._state = STATE_OFF
       "Get Volume"
@@ -363,3 +349,20 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     session = async_get_clientsession(hass)
     api = MultiRoomApi(ip, port, session, hass)
     async_add_entities([MultiRoomDevice(name, max_volume, power_options, api, unique_id)], True)
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up Samsung Soundbar from a config entry."""
+    data = config_entry.data
+    ip = data[CONF_HOST]
+    port = data.get(CONF_PORT, DEFAULT_PORT)
+    name = data.get(CONF_NAME, DEFAULT_NAME)
+    max_volume = int(data.get(CONF_MAX_VOLUME, DEFAULT_MAX_VOLUME))
+    if max_volume <= 0 or max_volume >= 100:
+      max_volume = 100
+    power_options = data.get(CONF_POWER_OPTIONS, DEFAULT_POWER_OPTIONS)
+    session = async_get_clientsession(hass)
+    api = MultiRoomApi(ip, port, session, hass)
+    async_add_entities(
+        [MultiRoomDevice(name, max_volume, power_options, api, config_entry.entry_id)],
+        True,
+    )

--- a/custom_components/samsung_soundbar/media_player.py
+++ b/custom_components/samsung_soundbar/media_player.py
@@ -76,7 +76,7 @@ class MultiRoomApi():
     url = '{0}/{1}?{2}'.format(self.endpoint, mode, query)
 
     try:
-      with async_timeout.timeout(TIMEOUT):
+      async with async_timeout.timeout(TIMEOUT):
         _LOGGER.debug("Executing: {} with cmd: {}".format(url, cmd))
         response = await self.session.get(url)
         data = await response.text()
@@ -126,7 +126,7 @@ class MultiRoomApi():
     await self._exec_set('UIC','SetVolume', 'volume', int(volume))
 
   async def get_speaker_name(self):
-    return await self._exec_get('UIC','GetSpkName', '<spkname>(.*?)</spkname>')
+    return await self._exec_get('UIC','GetSpkName', r'<spkname>(?:<!\[CDATA\[)?(.*?)(?:]]>)?</spkname>')
 
   async def get_radio_info(self):
     return await self._exec_get('CPM','GetRadioInfo', '<title>(.*?)</title>')

--- a/custom_components/samsung_soundbar/strings.json
+++ b/custom_components/samsung_soundbar/strings.json
@@ -1,0 +1,22 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Set up Samsung Soundbar",
+        "data": {
+          "host": "Host",
+          "name": "Name",
+          "port": "Port",
+          "max_volume": "Max Volume",
+          "power_options": "Enable Power Control"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect to the soundbar. Verify the host and port."
+    },
+    "abort": {
+      "already_configured": "This soundbar is already configured."
+    }
+  }
+}

--- a/custom_components/samsung_soundbar/strings.json
+++ b/custom_components/samsung_soundbar/strings.json
@@ -1,6 +1,11 @@
 {
   "config": {
+    "title": "Samsung Soundbar",
     "step": {
+      "confirm": {
+        "title": "Confirm Samsung Soundbar",
+        "description": "Found **{name}** at `{host}`. Do you want to add it?"
+      },
       "user": {
         "title": "Set up Samsung Soundbar",
         "data": {
@@ -16,7 +21,8 @@
       "cannot_connect": "Failed to connect to the soundbar. Verify the host and port."
     },
     "abort": {
-      "already_configured": "This soundbar is already configured."
+      "already_configured": "This soundbar is already configured.",
+      "not_samsung_soundbar": "The discovered device is not a Samsung WAM soundbar."
     }
   }
 }

--- a/custom_components/samsung_soundbar/translations/en.json
+++ b/custom_components/samsung_soundbar/translations/en.json
@@ -1,0 +1,22 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Set up Samsung Soundbar",
+        "data": {
+          "host": "Host",
+          "name": "Name",
+          "port": "Port",
+          "max_volume": "Max Volume",
+          "power_options": "Enable Power Control"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect to the soundbar. Verify the host and port."
+    },
+    "abort": {
+      "already_configured": "This soundbar is already configured."
+    }
+  }
+}

--- a/custom_components/samsung_soundbar/translations/en.json
+++ b/custom_components/samsung_soundbar/translations/en.json
@@ -1,6 +1,11 @@
 {
   "config": {
+    "title": "Samsung Soundbar",
     "step": {
+      "confirm": {
+        "title": "Confirm Samsung Soundbar",
+        "description": "Found **{name}** at `{host}`. Do you want to add it?"
+      },
       "user": {
         "title": "Set up Samsung Soundbar",
         "data": {
@@ -16,7 +21,8 @@
       "cannot_connect": "Failed to connect to the soundbar. Verify the host and port."
     },
     "abort": {
-      "already_configured": "This soundbar is already configured."
+      "already_configured": "This soundbar is already configured.",
+      "not_samsung_soundbar": "The discovered device is not a Samsung WAM soundbar."
     }
   }
 }

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Test configuration for Samsung Soundbar."""
+import pytest
+
+pytest_plugins = "pytest_homeassistant_custom_component"
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+  """Enable custom integrations for all tests."""
+  yield

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2,6 +2,7 @@
 from unittest.mock import AsyncMock, patch
 
 from homeassistant import config_entries
+from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
 from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -141,6 +142,93 @@ async def test_user_flow_duplicate_device(hass):
   ):
     result = await hass.config_entries.flow.async_configure(
       result["flow_id"], USER_INPUT
+    )
+
+  assert result["type"] == FlowResultType.ABORT
+  assert result["reason"] == "already_configured"
+
+
+SSDP_DISCOVERY_INFO = SsdpServiceInfo(
+  ssdp_usn="uuid:abc123",
+  ssdp_st="urn:schemas-upnp-org:device:MediaRenderer:1",
+  upnp={"manufacturer": "Samsung Electronics"},
+  ssdp_location="http://192.168.1.100:56001/description.xml",
+)
+
+
+async def test_ssdp_flow_shows_confirm(hass):
+  """Test that SSDP discovery shows the confirm form."""
+  with patch(
+    "custom_components.samsung_soundbar.config_flow.MultiRoomApi.get_speaker_name",
+    new_callable=AsyncMock,
+    return_value=["My Soundbar"],
+  ):
+    result = await hass.config_entries.flow.async_init(
+      DOMAIN,
+      context={"source": config_entries.SOURCE_SSDP},
+      data=SSDP_DISCOVERY_INFO,
+    )
+
+  assert result["type"] == FlowResultType.FORM
+  assert result["step_id"] == "confirm"
+
+
+async def test_ssdp_flow_confirm_creates_entry(hass):
+  """Test that confirming a discovered device creates a config entry."""
+  with patch(
+    "custom_components.samsung_soundbar.config_flow.MultiRoomApi.get_speaker_name",
+    new_callable=AsyncMock,
+    return_value=["My Soundbar"],
+  ):
+    result = await hass.config_entries.flow.async_init(
+      DOMAIN,
+      context={"source": config_entries.SOURCE_SSDP},
+      data=SSDP_DISCOVERY_INFO,
+    )
+
+  result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+  assert result["type"] == FlowResultType.CREATE_ENTRY
+  assert result["title"] == "My Soundbar"
+  assert result["data"][CONF_HOST] == "192.168.1.100"
+  assert result["data"][CONF_NAME] == "My Soundbar"
+
+
+async def test_ssdp_flow_not_samsung_soundbar(hass):
+  """Test that a non-soundbar device aborts with not_samsung_soundbar."""
+  with patch(
+    "custom_components.samsung_soundbar.config_flow.MultiRoomApi.get_speaker_name",
+    new_callable=AsyncMock,
+    return_value=None,
+  ):
+    result = await hass.config_entries.flow.async_init(
+      DOMAIN,
+      context={"source": config_entries.SOURCE_SSDP},
+      data=SSDP_DISCOVERY_INFO,
+    )
+
+  assert result["type"] == FlowResultType.ABORT
+  assert result["reason"] == "not_samsung_soundbar"
+
+
+async def test_ssdp_flow_already_configured(hass):
+  """Test that a duplicate SSDP discovery aborts with already_configured."""
+  entry = MockConfigEntry(
+    domain=DOMAIN,
+    unique_id=f"192.168.1.100:{DEFAULT_PORT}",
+    data={CONF_HOST: "192.168.1.100"},
+  )
+  entry.add_to_hass(hass)
+
+  with patch(
+    "custom_components.samsung_soundbar.config_flow.MultiRoomApi.get_speaker_name",
+    new_callable=AsyncMock,
+    return_value=["My Soundbar"],
+  ):
+    result = await hass.config_entries.flow.async_init(
+      DOMAIN,
+      context={"source": config_entries.SOURCE_SSDP},
+      data=SSDP_DISCOVERY_INFO,
     )
 
   assert result["type"] == FlowResultType.ABORT

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,147 @@
+"""Tests for Samsung Soundbar config flow."""
+from unittest.mock import AsyncMock, patch
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.data_entry_flow import FlowResultType
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.samsung_soundbar.const import (
+  DOMAIN,
+  DEFAULT_NAME,
+  DEFAULT_PORT,
+  DEFAULT_MAX_VOLUME,
+  DEFAULT_POWER_OPTIONS,
+  CONF_PORT,
+  CONF_MAX_VOLUME,
+  CONF_POWER_OPTIONS,
+)
+
+
+USER_INPUT = {
+  CONF_HOST: "192.168.1.100",
+  CONF_NAME: "Living Room Soundbar",
+  CONF_PORT: DEFAULT_PORT,
+  CONF_MAX_VOLUME: int(DEFAULT_MAX_VOLUME),
+  CONF_POWER_OPTIONS: DEFAULT_POWER_OPTIONS,
+}
+
+
+async def test_user_flow_shows_form(hass):
+  """Test that the user flow shows a form on first step."""
+  result = await hass.config_entries.flow.async_init(
+    DOMAIN, context={"source": config_entries.SOURCE_USER}
+  )
+  assert result["type"] == FlowResultType.FORM
+  assert result["step_id"] == "user"
+  assert result["errors"] == {}
+
+
+async def test_user_flow_success(hass):
+  """Test a successful user setup flow creates a config entry."""
+  result = await hass.config_entries.flow.async_init(
+    DOMAIN, context={"source": config_entries.SOURCE_USER}
+  )
+
+  with patch(
+    "custom_components.samsung_soundbar.config_flow.MultiRoomApi.get_speaker_name",
+    new_callable=AsyncMock,
+    return_value=["My Soundbar"],
+  ):
+    result = await hass.config_entries.flow.async_configure(
+      result["flow_id"], USER_INPUT
+    )
+
+  assert result["type"] == FlowResultType.CREATE_ENTRY
+  assert result["title"] == USER_INPUT[CONF_NAME]
+  assert result["data"][CONF_HOST] == USER_INPUT[CONF_HOST]
+  assert result["data"][CONF_PORT] == USER_INPUT[CONF_PORT]
+  assert result["data"][CONF_MAX_VOLUME] == USER_INPUT[CONF_MAX_VOLUME]
+  assert result["data"][CONF_POWER_OPTIONS] == USER_INPUT[CONF_POWER_OPTIONS]
+
+
+async def test_user_flow_cannot_connect(hass):
+  """Test that a connection failure shows an error and re-displays the form."""
+  result = await hass.config_entries.flow.async_init(
+    DOMAIN, context={"source": config_entries.SOURCE_USER}
+  )
+
+  with patch(
+    "custom_components.samsung_soundbar.config_flow.MultiRoomApi.get_speaker_name",
+    new_callable=AsyncMock,
+    return_value=None,
+  ):
+    result = await hass.config_entries.flow.async_configure(
+      result["flow_id"], USER_INPUT
+    )
+
+  assert result["type"] == FlowResultType.FORM
+  assert result["step_id"] == "user"
+  assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_user_flow_max_volume_stored(hass):
+  """Test that a nonzero max_volume value is stored in the entry."""
+  result = await hass.config_entries.flow.async_init(
+    DOMAIN, context={"source": config_entries.SOURCE_USER}
+  )
+
+  with patch(
+    "custom_components.samsung_soundbar.config_flow.MultiRoomApi.get_speaker_name",
+    new_callable=AsyncMock,
+    return_value=["My Soundbar"],
+  ):
+    result = await hass.config_entries.flow.async_configure(
+      result["flow_id"],
+      {**USER_INPUT, CONF_MAX_VOLUME: 25},
+    )
+
+  assert result["type"] == FlowResultType.CREATE_ENTRY
+  assert result["data"][CONF_MAX_VOLUME] == 25
+
+
+async def test_user_flow_max_volume_zero_stored(hass):
+  """Test that max_volume=0 (no limit) is stored as-is."""
+  result = await hass.config_entries.flow.async_init(
+    DOMAIN, context={"source": config_entries.SOURCE_USER}
+  )
+
+  with patch(
+    "custom_components.samsung_soundbar.config_flow.MultiRoomApi.get_speaker_name",
+    new_callable=AsyncMock,
+    return_value=["My Soundbar"],
+  ):
+    result = await hass.config_entries.flow.async_configure(
+      result["flow_id"],
+      {**USER_INPUT, CONF_MAX_VOLUME: 0},
+    )
+
+  assert result["type"] == FlowResultType.CREATE_ENTRY
+  assert result["data"][CONF_MAX_VOLUME] == 0
+
+
+async def test_user_flow_duplicate_device(hass):
+  """Test that configuring a duplicate host aborts with already_configured."""
+  entry = MockConfigEntry(
+    domain=DOMAIN,
+    unique_id=f"{USER_INPUT[CONF_HOST]}:{USER_INPUT[CONF_PORT]}",
+    data={CONF_HOST: USER_INPUT[CONF_HOST]},
+  )
+  entry.add_to_hass(hass)
+
+  result = await hass.config_entries.flow.async_init(
+    DOMAIN, context={"source": config_entries.SOURCE_USER}
+  )
+
+  with patch(
+    "custom_components.samsung_soundbar.config_flow.MultiRoomApi.get_speaker_name",
+    new_callable=AsyncMock,
+    return_value=["My Soundbar"],
+  ):
+    result = await hass.config_entries.flow.async_configure(
+      result["flow_id"], USER_INPUT
+    )
+
+  assert result["type"] == FlowResultType.ABORT
+  assert result["reason"] == "already_configured"

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -1,0 +1,123 @@
+"""Tests for Samsung Soundbar media player setup."""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.const import CONF_HOST, CONF_NAME
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.samsung_soundbar.const import (
+  DOMAIN,
+  DEFAULT_NAME,
+  DEFAULT_PORT,
+  DEFAULT_MAX_VOLUME,
+  DEFAULT_POWER_OPTIONS,
+  CONF_PORT,
+  CONF_MAX_VOLUME,
+  CONF_POWER_OPTIONS,
+)
+
+BASE_ENTRY_DATA = {
+  CONF_HOST: "192.168.1.100",
+  CONF_NAME: DEFAULT_NAME,
+  CONF_PORT: DEFAULT_PORT,
+  CONF_MAX_VOLUME: int(DEFAULT_MAX_VOLUME),
+  CONF_POWER_OPTIONS: DEFAULT_POWER_OPTIONS,
+}
+
+BASE_YAML_CONFIG = {
+  CONF_HOST: "192.168.1.100",
+  CONF_NAME: DEFAULT_NAME,
+  CONF_PORT: DEFAULT_PORT,
+  CONF_MAX_VOLUME: DEFAULT_MAX_VOLUME,  # string, as YAML delivers it
+  CONF_POWER_OPTIONS: DEFAULT_POWER_OPTIONS,
+}
+
+
+async def _setup_entry(hass, data):
+  """Helper: set up a config entry and return the created entities."""
+  entry = MockConfigEntry(domain=DOMAIN, unique_id=data[CONF_HOST], data=data)
+  entities = []
+
+  with patch("custom_components.samsung_soundbar.media_player.async_get_clientsession"):
+    from custom_components.samsung_soundbar.media_player import async_setup_entry
+    await async_setup_entry(hass, entry, lambda e, *_: entities.extend(e))
+
+  return entities
+
+
+async def _setup_platform(hass, config):
+  """Helper: set up via YAML platform path and return the created entities."""
+  entities = []
+
+  with patch("custom_components.samsung_soundbar.media_player.async_get_clientsession"):
+    from custom_components.samsung_soundbar.media_player import async_setup_platform
+    await async_setup_platform(hass, config, lambda e, *_: entities.extend(e))
+
+  return entities
+
+
+# --- Config entry (UI) path ---
+
+async def test_max_volume_applied_when_nonzero(hass):
+  """When max_volume is between 1-99, the entity uses that value."""
+  entities = await _setup_entry(hass, {**BASE_ENTRY_DATA, CONF_MAX_VOLUME: 25})
+  assert entities[0]._max_volume == 25
+
+
+async def test_max_volume_100_when_zero(hass):
+  """When max_volume is 0 (no limit), the entity uses 100."""
+  entities = await _setup_entry(hass, {**BASE_ENTRY_DATA, CONF_MAX_VOLUME: 0})
+  assert entities[0]._max_volume == 100
+
+
+async def test_max_volume_100_when_100(hass):
+  """When max_volume is 100 (no limit), the entity uses 100."""
+  entities = await _setup_entry(hass, {**BASE_ENTRY_DATA, CONF_MAX_VOLUME: 100})
+  assert entities[0]._max_volume == 100
+
+
+# --- YAML platform path ---
+
+async def test_yaml_max_volume_applied(hass):
+  """YAML setup uses the configured max_volume string value."""
+  entities = await _setup_platform(hass, {**BASE_YAML_CONFIG, CONF_MAX_VOLUME: "25"})
+  assert entities[0]._max_volume == 25
+
+
+async def test_yaml_set_volume_scales_by_max_volume(hass):
+  """set_volume_level sends volume * max_volume to the device."""
+  entities = await _setup_platform(hass, {**BASE_YAML_CONFIG, CONF_MAX_VOLUME: "40"})
+  entity = entities[0]
+  entity.api.set_volume = AsyncMock()
+
+  await entity.async_set_volume_level(0.5)
+
+  entity.api.set_volume.assert_called_once_with(20.0)
+
+
+async def test_yaml_update_scales_volume_from_device(hass):
+  """async_update divides raw device volume by the default max_volume (40)."""
+  entities = await _setup_platform(hass, BASE_YAML_CONFIG)
+  entity = entities[0]
+  entity.api.get_state = AsyncMock(return_value="1")
+  entity.api.get_source = AsyncMock(return_value=["hdmi1", False])
+  entity.api.get_volume = AsyncMock(return_value=["10"])
+  entity.api.get_muted = AsyncMock(return_value=False)
+
+  await entity.async_update()
+
+  assert entity._volume == 0.25
+
+
+async def test_yaml_update_scales_volume_from_device_nondefault_max(hass):
+  """async_update scaling works correctly with a non-default max_volume."""
+  entities = await _setup_platform(hass, {**BASE_YAML_CONFIG, CONF_MAX_VOLUME: "60"})
+  entity = entities[0]
+  entity.api.get_state = AsyncMock(return_value="1")
+  entity.api.get_source = AsyncMock(return_value=["hdmi1", False])
+  entity.api.get_volume = AsyncMock(return_value=["15"])
+  entity.api.get_muted = AsyncMock(return_value=False)
+
+  await entity.async_update()
+
+  assert entity._volume == 0.25

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -1,6 +1,8 @@
 """Tests for Samsung Soundbar media player setup."""
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from custom_components.samsung_soundbar.media_player import MultiRoomApi
+
 from homeassistant.const import CONF_HOST, CONF_NAME
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -108,6 +110,30 @@ async def test_yaml_update_scales_volume_from_device(hass):
 
   assert entity._volume == 0.25
 
+
+# --- MultiRoomApi ---
+
+def _make_api(xml_response):
+  """Return a MultiRoomApi whose session returns the given XML string."""
+  mock_response = MagicMock()
+  mock_response.text = AsyncMock(return_value=xml_response)
+  session = MagicMock()
+  session.get = AsyncMock(return_value=mock_response)
+  return MultiRoomApi("192.168.1.100", "56001", session, None)
+
+
+async def test_get_speaker_name_plain(hass):
+  """get_speaker_name returns the name when it is a plain string."""
+  api = _make_api("<UIC><response result='ok'><spkname>Office Soundbar</spkname></response></UIC>")
+  result = await api.get_speaker_name()
+  assert result == ["Office Soundbar"]
+
+
+async def test_get_speaker_name_cdata(hass):
+  """get_speaker_name strips CDATA wrapper and returns the bare name."""
+  api = _make_api("<UIC><response result='ok'><spkname><![CDATA[Office Soundbar]]></spkname></response></UIC>")
+  result = await api.get_speaker_name()
+  assert result == ["Office Soundbar"]
 
 async def test_yaml_update_scales_volume_from_device_nondefault_max(hass):
   """async_update scaling works correctly with a non-default max_volume."""


### PR DESCRIPTION
This pair of commits adds the capability to configure the integration via the UI. It also adds autodiscovery support so you can get prompted to add any soundbars discovered on the local network.

AI disclosure & quality control: I did use Claude as an aide here, but I was pretty careful in reviewing all of the changes directly. I also provided the list of test cases and spent a fair amount of time making sure the test cases are actually covering the scenarios I specified.

I tested this quite a lot with the soundbar I have access to (Q900A-HW) and made sure that things worked as expected when configured manually via config file, configured via UI, and configured via autodiscovery.