### PR TITLE
Airplay mode detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## 1.3.0 (2026-04-25)
+
+- Added AirPlay source detection for soundbars in Wifi mode; probes using mDNS
+
+## 1.2.0 (2026-04-23)
+
+- Switched to XML parsing for device API responses, improving reliability with
+  devices that return malformed or unexpected results (notably the HW-Q900A in
+  certain Wifi modes)
+- Improved robustness of source/function state retrieval
+- Internal refactoring of API call structure
+
+## 1.1.0 (2026-03-30)
+
+- Added UI-driven configuration flow; YAML configuration remains supported
+- Added UPnP/SSDP-based autodiscovery for compatible Samsung soundbars
+
+## Earlier editions
+
+Prior to 1.1.0, configuration was handled entirely via YAML. Various bug fixes and
+compatibility updates were made over time for Home Assistant API changes and device
+quirks.

--- a/custom_components/samsung_soundbar/__init__.py
+++ b/custom_components/samsung_soundbar/__init__.py
@@ -1,0 +1,15 @@
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+PLATFORMS = ["media_player"]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+  """Set up Samsung Soundbar from a config entry."""
+  await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+  return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+  """Unload a config entry."""
+  return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/custom_components/samsung_soundbar/airplay_detect.py
+++ b/custom_components/samsung_soundbar/airplay_detect.py
@@ -1,0 +1,157 @@
+"""AirPlay session detection via unicast mDNS probe."""
+import asyncio
+import struct
+
+_MDNS_PORT = 5353
+_RAOP_SERVICE = "_raop._tcp.local"
+# Set while an AirPlay session is active; clear when idle.
+_SF_SESSION_ACTIVE = 0x0800
+
+
+def _encode_name(name: str) -> bytes:
+    result = b""
+    for label in name.rstrip(".").split("."):
+        enc = label.encode()
+        result += bytes([len(enc)]) + enc
+    return result + b"\x00"
+
+
+def _build_query(name: str) -> bytes:
+    header = struct.pack(">HHHHHH", 0x0001, 0x0000, 1, 0, 0, 0)
+    question = _encode_name(name) + struct.pack(">HH", 255, 1)  # ANY, class IN
+    return header + question
+
+
+def _parse_name(data: bytes, offset: int):
+    labels = []
+    visited = set()
+    while offset < len(data):
+        length = data[offset]
+        if length == 0:
+            offset += 1
+            break
+        if (length & 0xC0) == 0xC0:
+            if offset + 1 >= len(data):
+                break
+            ptr = ((length & 0x3F) << 8) | data[offset + 1]
+            if ptr in visited:
+                break
+            visited.add(ptr)
+            name, _ = _parse_name(data, ptr)
+            labels.append(name)
+            offset += 2
+            break
+        offset += 1
+        labels.append(data[offset:offset + length].decode(errors="replace"))
+        offset += length
+    return ".".join(labels), offset
+
+
+def _parse_txt_record(rdata: bytes) -> dict:
+    result = {}
+    pos = 0
+    while pos < len(rdata):
+        length = rdata[pos]
+        pos += 1
+        if length == 0 or pos + length > len(rdata):
+            break
+        item = rdata[pos:pos + length]
+        pos += length
+        if b"=" in item:
+            k, _, v = item.partition(b"=")
+            result[k.decode(errors="replace")] = v.decode(errors="replace")
+        else:
+            result[item.decode(errors="replace")] = ""
+    return result
+
+
+def _parse_response(data: bytes) -> list:
+    if len(data) < 12:
+        return []
+    _tid, _flags, qdcount, ancount, nscount, arcount = struct.unpack(">HHHHHH", data[:12])
+    offset = 12
+    for _ in range(qdcount):
+        _, offset = _parse_name(data, offset)
+        offset += 4
+    records = []
+    for _ in range(ancount + nscount + arcount):
+        if offset >= len(data):
+            break
+        name, offset = _parse_name(data, offset)
+        if offset + 10 > len(data):
+            break
+        rtype, _rclass, _ttl, rdlen = struct.unpack(">HHIH", data[offset:offset + 10])
+        offset += 10
+        rdata_offset = offset
+        rdata = data[offset:offset + rdlen]
+        offset += rdlen
+        rec = {"name": name, "type": rtype}
+        if rtype == 12:  # PTR — rdata is an encoded name; parse from original packet for pointer support
+            rec["ptr"], _ = _parse_name(data, rdata_offset)
+        elif rtype == 16:  # TXT
+            rec["txt"] = _parse_txt_record(rdata)
+        records.append(rec)
+    return records
+
+
+class _RaopProtocol(asyncio.DatagramProtocol):
+    def __init__(self, future: asyncio.Future) -> None:
+        self._future = future
+
+    def datagram_received(self, data: bytes, addr) -> None:
+        if not self._future.done():
+            self._future.set_result(data)
+
+    def error_received(self, exc: Exception) -> None:
+        if not self._future.done():
+            self._future.set_exception(exc)
+
+    def connection_lost(self, exc) -> None:
+        if exc and not self._future.done():
+            self._future.set_exception(exc)
+
+
+async def _probe(loop, ip: str, query: bytes, timeout: float):
+    """Send one UDP query to ip:5353 and return the first response packet, or None."""
+    future = loop.create_future()
+    transport, _ = await loop.create_datagram_endpoint(
+        lambda: _RaopProtocol(future),
+        remote_addr=(ip, _MDNS_PORT),
+    )
+    try:
+        transport.sendto(query)
+        return await asyncio.wait_for(future, timeout=timeout)
+    except Exception:
+        return None
+    finally:
+        transport.close()
+
+
+async def is_airplay_active(ip: str, timeout: float = 1.0) -> bool:
+    """Return True if an AirPlay session is active on the soundbar at *ip*."""
+    try:
+        loop = asyncio.get_running_loop()
+
+        # Step 1: PTR query to discover the service instance name.
+        ptr_data = await _probe(loop, ip, _build_query(_RAOP_SERVICE), timeout)
+        if ptr_data is None:
+            return False
+        instance_names = [
+            rec["ptr"] for rec in _parse_response(ptr_data)
+            if rec["type"] == 12 and "_raop._tcp" in rec.get("ptr", "")
+        ]
+        if not instance_names:
+            return False
+
+        # Step 2: TXT query for the instance to read the session-active flag.
+        txt_data = await _probe(loop, ip, _build_query(instance_names[0]), timeout)
+        if txt_data is None:
+            return False
+        for rec in _parse_response(txt_data):
+            if rec["type"] == 16 and "_raop._tcp" in rec.get("name", ""):
+                sf_raw = rec.get("txt", {}).get("sf")
+                if sf_raw is not None:
+                    return bool(int(sf_raw, 16) & _SF_SESSION_ACTIVE)
+        return False
+    except Exception:
+        return False

--- a/custom_components/samsung_soundbar/config_flow.py
+++ b/custom_components/samsung_soundbar/config_flow.py
@@ -1,0 +1,64 @@
+import voluptuous as vol
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.selector import (
+  NumberSelector,
+  NumberSelectorConfig,
+  NumberSelectorMode,
+)
+
+from .const import (
+  DOMAIN,
+  DEFAULT_NAME,
+  DEFAULT_PORT,
+  DEFAULT_MAX_VOLUME,
+  DEFAULT_POWER_OPTIONS,
+  CONF_PORT,
+  CONF_MAX_VOLUME,
+  CONF_POWER_OPTIONS,
+)
+from .media_player import MultiRoomApi
+
+
+class SamsungSoundbarConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+  """Handle a config flow for Samsung Soundbar."""
+
+  VERSION = 1
+
+  async def async_step_user(self, user_input=None):
+    """Handle the initial step."""
+    errors = {}
+
+    if user_input is not None:
+      host = user_input[CONF_HOST]
+      port = user_input.get(CONF_PORT, DEFAULT_PORT)
+      session = async_get_clientsession(self.hass)
+      api = MultiRoomApi(host, port, session, self.hass)
+
+      # Basic connectivity test
+      speaker_name = await api.get_speaker_name()
+
+      if speaker_name:
+        await self.async_set_unique_id(f"{host}:{port}")
+        self._abort_if_unique_id_configured()
+        return self.async_create_entry(
+          title=user_input.get(CONF_NAME, DEFAULT_NAME),
+          data=user_input,
+        )
+      errors["base"] = "cannot_connect"
+
+    return self.async_show_form(
+      step_id="user",
+      data_schema=vol.Schema({
+        vol.Required(CONF_HOST): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.string,
+        vol.Required(CONF_MAX_VOLUME, default=int(DEFAULT_MAX_VOLUME)): NumberSelector(
+          NumberSelectorConfig(min=0, max=100, step=1, mode=NumberSelectorMode.SLIDER)
+        ),
+        vol.Required(CONF_POWER_OPTIONS, default=DEFAULT_POWER_OPTIONS): cv.boolean,
+      }),
+      errors=errors,
+    )

--- a/custom_components/samsung_soundbar/config_flow.py
+++ b/custom_components/samsung_soundbar/config_flow.py
@@ -1,5 +1,7 @@
 import voluptuous as vol
+from urllib.parse import urlparse
 from homeassistant import config_entries
+from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
 from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -61,4 +63,45 @@ class SamsungSoundbarConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         vol.Required(CONF_POWER_OPTIONS, default=DEFAULT_POWER_OPTIONS): cv.boolean,
       }),
       errors=errors,
+    )
+
+  async def async_step_ssdp(self, discovery_info: SsdpServiceInfo):
+    """Handle SSDP discovery."""
+    host = urlparse(discovery_info.ssdp_location).hostname
+    port = DEFAULT_PORT
+    session = async_get_clientsession(self.hass)
+    api = MultiRoomApi(host, port, session, self.hass)
+
+    speaker_name = await api.get_speaker_name()
+    if not speaker_name:
+      return self.async_abort(reason="not_samsung_soundbar")
+
+    await self.async_set_unique_id(f"{host}:{port}")
+    self._abort_if_unique_id_configured()
+
+    self._discovered_host = host
+    self._discovered_name = speaker_name[0] if isinstance(speaker_name, list) else speaker_name
+    self.context["title_placeholders"] = {"name": self._discovered_name}
+    return await self.async_step_confirm()
+
+  async def async_step_confirm(self, user_input=None):
+    """Confirm adding a discovered device."""
+    if user_input is not None:
+      return self.async_create_entry(
+        title=self._discovered_name,
+        data={
+          CONF_HOST: self._discovered_host,
+          CONF_NAME: self._discovered_name,
+          CONF_PORT: DEFAULT_PORT,
+          CONF_MAX_VOLUME: int(DEFAULT_MAX_VOLUME),
+          CONF_POWER_OPTIONS: DEFAULT_POWER_OPTIONS,
+        },
+      )
+
+    return self.async_show_form(
+      step_id="confirm",
+      description_placeholders={
+        "name": self._discovered_name,
+        "host": self._discovered_host,
+      },
     )

--- a/custom_components/samsung_soundbar/const.py
+++ b/custom_components/samsung_soundbar/const.py
@@ -1,0 +1,24 @@
+DOMAIN = "samsung_soundbar"
+
+CONF_PORT = 'port'
+CONF_MAX_VOLUME = 'max_volume'
+CONF_POWER_OPTIONS = 'power_options'
+
+DEFAULT_NAME = 'Samsung Soundbar'
+DEFAULT_PORT = '56001'
+DEFAULT_POWER_OPTIONS = True
+DEFAULT_MAX_VOLUME = '40'
+
+BOOL_OFF = 'off'
+BOOL_ON = 'on'
+TIMEOUT = 2
+
+MULTI_ROOM_SOURCE_TYPE = [
+    'digital',
+    'hdmi1',
+    'hdmi2',
+    'optical',
+    'bt',
+    'aux',
+    'wifi',
+]

--- a/custom_components/samsung_soundbar/manifest.json
+++ b/custom_components/samsung_soundbar/manifest.json
@@ -2,12 +2,12 @@
   "domain": "samsung_soundbar",
   "name": "Samsung Soundbar",
   "documentation": "https://github.com/IDmedia/hass-samsung_soundbar",
-  "dependencies": ["http"],
-  "version": "1.0.1",
+  "version": "1.1.0",
   "codeowners": [
     "@IDmedia"
   ],
   "requirements": [
     "xmltodict==0.11.0"
-  ]
+  ],
+  "config_flow": true
 }

--- a/custom_components/samsung_soundbar/manifest.json
+++ b/custom_components/samsung_soundbar/manifest.json
@@ -9,5 +9,14 @@
   "requirements": [
     "xmltodict==0.11.0"
   ],
-  "config_flow": true
+  "config_flow": true,
+  "ssdp": [
+    {
+      "st": "urn:schemas-upnp-org:device:MediaRenderer:1",
+      "manufacturer": "Samsung Electronics"
+    },
+    {
+      "st": "urn:samsung.com:device:RemoteControlReceiver:1"
+    }
+  ]
 }

--- a/custom_components/samsung_soundbar/manifest.json
+++ b/custom_components/samsung_soundbar/manifest.json
@@ -2,7 +2,7 @@
   "domain": "samsung_soundbar",
   "name": "Samsung Soundbar",
   "documentation": "https://github.com/IDmedia/hass-samsung_soundbar",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "codeowners": [
     "@IDmedia"
   ],

--- a/custom_components/samsung_soundbar/manifest.json
+++ b/custom_components/samsung_soundbar/manifest.json
@@ -2,7 +2,7 @@
   "domain": "samsung_soundbar",
   "name": "Samsung Soundbar",
   "documentation": "https://github.com/IDmedia/hass-samsung_soundbar",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "codeowners": [
     "@IDmedia"
   ],

--- a/custom_components/samsung_soundbar/media_player.py
+++ b/custom_components/samsung_soundbar/media_player.py
@@ -12,10 +12,6 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 _LOGGER = logging.getLogger(__name__)
 
-VERSION = '1.0.0'
-
-DOMAIN = "samsung_soundbar"
-
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=3)
 MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(seconds=3)
 
@@ -37,35 +33,25 @@ from homeassistant.const import (
   STATE_OFF
 )
 
-MULTI_ROOM_SOURCE_TYPE = [
-  'digital',
-  'hdmi1',
-  'hdmi2',
-  'optical',
-  'bt',
-  'aux',
-  'wifi'
-]
+from .const import (
+  DEFAULT_NAME,
+  DEFAULT_PORT,
+  DEFAULT_MAX_VOLUME,
+  DEFAULT_POWER_OPTIONS,
+  BOOL_OFF,
+  BOOL_ON,
+  TIMEOUT,
+  MULTI_ROOM_SOURCE_TYPE,
+  CONF_PORT,
+  CONF_MAX_VOLUME,
+  CONF_POWER_OPTIONS,
+)
 
-DEFAULT_NAME = 'Samsung Soundbar'
-DEFAULT_PORT = '56001'
-DEFAULT_POWER_OPTIONS = True
-DEFAULT_MAX_VOLUME = '40'
-BOOL_OFF = 'off'
-BOOL_ON = 'on'
-TIMEOUT = 2
 SUPPORT_SAMSUNG_MULTI_ROOM = (
   MediaPlayerEntityFeature.VOLUME_SET
   | MediaPlayerEntityFeature.VOLUME_MUTE
   | MediaPlayerEntityFeature.SELECT_SOURCE
 )
-
-
-MediaPlayerEntityFeature
-
-CONF_MAX_VOLUME = 'max_volume'
-CONF_PORT = 'port'
-CONF_POWER_OPTIONS = 'power_options'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
   vol.Required(CONF_HOST, default='127.0.0.1'): cv.string,
@@ -340,7 +326,7 @@ class MultiRoomDevice(MediaPlayerEntity):
       source = await self.api.get_source()
       if source:
         self._current_source = source[0]
-        self._state = STATE_PLAYING
+        self._state = STATE_ON
       else:
         self._state = STATE_OFF
       "Get Volume"
@@ -363,3 +349,20 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     session = async_get_clientsession(hass)
     api = MultiRoomApi(ip, port, session, hass)
     async_add_entities([MultiRoomDevice(name, max_volume, power_options, api, unique_id)], True)
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up Samsung Soundbar from a config entry."""
+    data = config_entry.data
+    ip = data[CONF_HOST]
+    port = data.get(CONF_PORT, DEFAULT_PORT)
+    name = data.get(CONF_NAME, DEFAULT_NAME)
+    max_volume = int(data.get(CONF_MAX_VOLUME, DEFAULT_MAX_VOLUME))
+    if max_volume <= 0 or max_volume >= 100:
+      max_volume = 100
+    power_options = data.get(CONF_POWER_OPTIONS, DEFAULT_POWER_OPTIONS)
+    session = async_get_clientsession(hass)
+    api = MultiRoomApi(ip, port, session, hass)
+    async_add_entities(
+        [MultiRoomDevice(name, max_volume, power_options, api, config_entry.entry_id)],
+        True,
+    )

--- a/custom_components/samsung_soundbar/media_player.py
+++ b/custom_components/samsung_soundbar/media_player.py
@@ -76,7 +76,7 @@ class MultiRoomApi():
     url = '{0}/{1}?{2}'.format(self.endpoint, mode, query)
 
     try:
-      with async_timeout.timeout(TIMEOUT):
+      async with async_timeout.timeout(TIMEOUT):
         _LOGGER.debug("Executing: {} with cmd: {}".format(url, cmd))
         response = await self.session.get(url)
         data = await response.text()
@@ -126,7 +126,7 @@ class MultiRoomApi():
     await self._exec_set('UIC','SetVolume', 'volume', int(volume))
 
   async def get_speaker_name(self):
-    return await self._exec_get('UIC','GetSpkName', '<spkname>(.*?)</spkname>')
+    return await self._exec_get('UIC','GetSpkName', r'<spkname>(?:<!\[CDATA\[)?(.*?)(?:]]>)?</spkname>')
 
   async def get_radio_info(self):
     return await self._exec_get('CPM','GetRadioInfo', '<title>(.*?)</title>')

--- a/custom_components/samsung_soundbar/media_player.py
+++ b/custom_components/samsung_soundbar/media_player.py
@@ -122,9 +122,6 @@ class MultiRoomApi():
     _LOGGER.warning("_exec_get_xml: no %s response after %d attempts", expected_method, retries)
     return None
 
-  async def _exec_get(self, mode, action, key_to_extract):
-    return await self._exec_cmd_legacy(mode, '<name>{0}</name>'.format(action), key_to_extract)
-
   async def _exec_set(self, mode, action, property_name, value):
     if type(value) is str:
       value_type = 'str'
@@ -149,9 +146,6 @@ class MultiRoomApi():
 
   async def set_state(self, key):
     await self._exec_set('UIC','SetPowerStatus', 'powerStatus', int(key))
-
-  async def get_main_info(self):
-    return await self._exec_get('UIC','GetMainInfo')
 
   async def get_volume(self):
     response = await self._exec_get_xml('UIC', 'GetVolume', 'VolumeLevel')

--- a/custom_components/samsung_soundbar/media_player.py
+++ b/custom_components/samsung_soundbar/media_player.py
@@ -183,31 +183,19 @@ class MultiRoomApi():
       await self._exec_set('UIC','SetMute', 'mute', BOOL_OFF)
 
   async def get_source(self):
-    wifi_fallback = {'mode': 'wifi', 'submode': False}
-    data = await self._exec_cmd('UIC', '<name>GetFunc</name>', timeout=0.5)
-    if not data:
-      # GetFunc in WiFi mode blocks until an unsolicited push event (e.g. VolumeLevel) arrives
-      # instead of responding with CurrentFunc, so a timeout or empty response means WiFi mode.
-      return wifi_fallback
-    try:
-      parsed = xmltodict.parse(data)
-      uic = parsed.get('UIC', {})
-      # A non-CurrentFunc response (e.g. VolumeLevel, PowerStatus) also indicates WiFi mode.
-      # These are just unsolicited push events that happen to arrive while we're waiting.
-      if uic.get('method') != 'CurrentFunc':
-        return wifi_fallback
-      response = uic.get('response', {})
-      if response.get('@result') != 'ok':
-        return None
-      function = response.get('function')
-      if function is None:
-        return None
-      if function == 'bt':
-        return {'mode': function, 'submode': False}
-      submode = response.get('submode')
-      return {'mode': function, 'submode': 'TuneIn' if submode == 'cp' else False}
-    except Exception:
+    # GetFunc in WiFi mode never returns CurrentFunc — it times out or delivers push events.
+    # _exec_get_xml retries on wrong-method responses and returns None on timeout or exhaustion;
+    # both map to wifi_fallback here.
+    response = await self._exec_get_xml('UIC', 'GetFunc', 'CurrentFunc', timeout=0.5)
+    if response is None:
+      return {'mode': 'wifi', 'submode': False}
+    function = response.get('function')
+    if function is None:
       return None
+    if function == 'bt':
+      return {'mode': function, 'submode': False}
+    submode = response.get('submode')
+    return {'mode': function, 'submode': 'TuneIn' if submode == 'cp' else False}
 
   async def set_source(self, source):
     SEPARATOR = ' - '

--- a/custom_components/samsung_soundbar/media_player.py
+++ b/custom_components/samsung_soundbar/media_player.py
@@ -71,11 +71,11 @@ class MultiRoomApi():
     self.port = port
     self.endpoint = 'http://{0}:{1}'.format(ip, port)
 
-  async def _exec_cmd(self, mode, cmd):
+  async def _exec_cmd(self, mode, cmd, timeout=TIMEOUT):
     query = urllib.parse.urlencode({ "cmd": cmd }, quote_via=urllib.parse.quote)
     url = '{0}/{1}?{2}'.format(self.endpoint, mode, query)
     try:
-      async with async_timeout.timeout(TIMEOUT):
+      async with async_timeout.timeout(timeout):
         _LOGGER.debug("Executing: {} with cmd: {}".format(url, cmd))
         response = await self.session.get(url)
         data = await response.text()
@@ -158,17 +158,19 @@ class MultiRoomApi():
       await self._exec_set('UIC','SetMute', 'mute', BOOL_OFF)
 
   async def get_source(self):
-    data = await self._exec_cmd('UIC', '<name>GetFunc</name>')
+    wifi_fallback = {'mode': 'wifi', 'submode': False}
+    data = await self._exec_cmd('UIC', '<name>GetFunc</name>', timeout=0.5)
     if not data:
-      return None
+      # GetFunc in WiFi mode blocks until an unsolicited push event (e.g. VolumeLevel) arrives
+      # instead of responding with CurrentFunc, so a timeout or empty response means WiFi mode.
+      return wifi_fallback
     try:
       parsed = xmltodict.parse(data)
       uic = parsed.get('UIC', {})
-      # When in WiFi mode, GetFunc may return a non-CurrentFunc response (e.g. VolumeLevel,
-      # PowerStatus) instead of a CurrentFunc response with a <function> element.
-      # This seems to only happen in WiFi mode, so just assume that's the state.
+      # A non-CurrentFunc response (e.g. VolumeLevel, PowerStatus) also indicates WiFi mode.
+      # These are just unsolicited push events that happen to arrive while we're waiting.
       if uic.get('method') != 'CurrentFunc':
-        return {'mode': 'wifi', 'submode': False}
+        return wifi_fallback
       response = uic.get('response', {})
       if response.get('@result') != 'ok':
         return None

--- a/custom_components/samsung_soundbar/media_player.py
+++ b/custom_components/samsung_soundbar/media_player.py
@@ -34,6 +34,7 @@ from homeassistant.const import (
   STATE_OFF
 )
 
+from .airplay_detect import is_airplay_active
 from .const import (
   DEFAULT_NAME,
   DEFAULT_PORT,
@@ -182,7 +183,8 @@ class MultiRoomApi():
     # both map to wifi_fallback here.
     response = await self._exec_get_xml('UIC', 'GetFunc', 'CurrentFunc', timeout=0.5)
     if response is None:
-      return {'mode': 'wifi', 'submode': False}
+      airplay = await is_airplay_active(self.ip)
+      return {'mode': 'wifi', 'submode': 'AirPlay' if airplay else False}
     function = response.get('function')
     if function is None:
       return None
@@ -315,6 +317,9 @@ class MultiRoomDevice(MediaPlayerEntity):
       await self._refresh_active_state()
       if self._mode == 'TuneIn':
         await self._refresh_media_info()
+      elif self._mode == 'AirPlay':
+        self._media_title = 'AirPlay'
+        self._image_url = None
       else:
         self._media_title = ''
         self._image_url = None

--- a/custom_components/samsung_soundbar/media_player.py
+++ b/custom_components/samsung_soundbar/media_player.py
@@ -142,9 +142,9 @@ class MultiRoomApi():
     return await self._exec_cmd_legacy(mode, cmd, property_name)
 
   async def get_state(self):
-    result = await self._exec_get('UIC','GetPowerStatus', '<powerStatus>(.*?)</powerStatus>')
-    if result:
-      return result[0]
+    response = await self._exec_get_xml('UIC', 'GetPowerStatus', 'PowerStatus')
+    if response:
+      return response.get('powerStatus')
     return 0
 
   async def set_state(self, key):
@@ -154,22 +154,27 @@ class MultiRoomApi():
     return await self._exec_get('UIC','GetMainInfo')
 
   async def get_volume(self):
-    return await self._exec_get('UIC','GetVolume', '<volume>(.*?)</volume')
+    response = await self._exec_get_xml('UIC', 'GetVolume', 'VolumeLevel')
+    return response.get('volume') if response else None
 
   async def set_volume(self, volume):
     await self._exec_set('UIC','SetVolume', 'volume', int(volume))
 
   async def get_speaker_name(self):
-    return await self._exec_get('UIC','GetSpkName', r'<spkname>(?:<!\[CDATA\[)?(.*?)(?:]]>)?</spkname>')
+    response = await self._exec_get_xml('UIC', 'GetSpkName', 'SpkName')
+    return response.get('spkname') if response else None
 
   async def get_radio_info(self):
-    return await self._exec_get('CPM','GetRadioInfo', '<title>(.*?)</title>')
+    response = await self._exec_get_xml('CPM', 'GetRadioInfo', 'RadioInfo')
+    return response.get('title') if response else None
 
   async def get_radio_image(self):
-    return await self._exec_get('CPM','GetRadioInfo', '<thumbnail>(.*?)</thumbnail>')
+    response = await self._exec_get_xml('CPM', 'GetRadioInfo', 'RadioInfo')
+    return response.get('thumbnail') if response else None
 
   async def get_muted(self):
-    return await self._exec_get('UIC','GetMute', '<mute>(.*?)</mute>') == BOOL_ON
+    response = await self._exec_get_xml('UIC', 'GetMute', 'MuteStatus')
+    return response.get('mute') == BOOL_ON if response else False
 
   async def set_muted(self, mute):
     if mute:
@@ -361,8 +366,8 @@ class MultiRoomDevice(MediaPlayerEntity):
   async def _refresh_volume(self):
     try:
       volume = await self.api.get_volume()
-      if volume and volume[0]:
-        self._volume = int(volume[0]) / self._max_volume
+      if volume:
+        self._volume = int(volume) / self._max_volume
     except Exception:
       _LOGGER.error("Failed to get volume")
 
@@ -374,10 +379,10 @@ class MultiRoomDevice(MediaPlayerEntity):
   async def _refresh_media_info(self):
     title = await self.api.get_radio_info()
     if title:
-      self._media_title = str(title[0])
+      self._media_title = str(title)
     image = await self.api.get_radio_image()
     if image:
-      self._image_url = str(image[0])
+      self._image_url = str(image)
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Samsung MultiRoom platform asynchronously."""

--- a/custom_components/samsung_soundbar/media_player.py
+++ b/custom_components/samsung_soundbar/media_player.py
@@ -293,69 +293,69 @@ class MultiRoomDevice(MediaPlayerEntity):
   async def async_update(self):
     """Update the media player State."""
     _LOGGER.info('Refreshing state...')
-    "Update with power options"
     if self._power_options:
-      "Get Power State"
-      state = await self.api.get_state()
-      _LOGGER.debug(state)
-      if state and int(state) == 1:
-        "If Power is ON, update other values"
-        self._state = STATE_ON
-        "Get Current Source"
-        source = await self.api.get_source()
-        if source is not None:
-          if source['mode']:
-            self._current_source = source['mode']
-          if source['submode']:
-            self._mode = source['submode']
-          else:
-            self._mode = ''
-        else:
-            self._mode = ''
-        try:
-          "Get Volume"
-          volume = await self.api.get_volume()
-          if volume[0]:
-            self._volume = int(volume[0]) / self._max_volume
-        except:
-          _LOGGER.error("Failed to get volume")
-        "Get Mute State"
-        muted = await self.api.get_muted()
-        if muted:
-          self._muted = muted
-        if self._mode == 'TuneIn':
-          title = await self.api.get_radio_info()
-          if title:
-            self._media_title = str(title[0])
-          image = await self.api.get_radio_image()
-          if image:
-            self._image_url = str(image[0])
-        else:
-          self._media_title = ''
-          self._image_url = None
+      await self._update_with_power_options()
+    else:
+      await self._update_without_power_options()
+
+  async def _update_with_power_options(self):
+    state = await self.api.get_state()
+    _LOGGER.debug(state)
+    if state and int(state) == 1:
+      self._state = STATE_ON
+      await self._refresh_active_state()
+      if self._mode == 'TuneIn':
+        await self._refresh_media_info()
       else:
-        self._state = STATE_OFF
         self._media_title = ''
         self._image_url = None
     else:
-      "Update without power options"
+      self._state = STATE_OFF
       self._media_title = ''
       self._image_url = None
-      "Get Current Source"
-      source = await self.api.get_source()
-      if source:
-        self._current_source = source['mode']
-        self._state = STATE_ON
-      else:
-        self._state = STATE_OFF
-      "Get Volume"
+
+  async def _update_without_power_options(self):
+    self._media_title = ''
+    self._image_url = None
+    source = await self.api.get_source()
+    self._state = STATE_ON if source else STATE_OFF
+    self._apply_source(source)
+    await self._refresh_volume()
+    await self._refresh_mute()
+
+  async def _refresh_active_state(self):
+    source = await self.api.get_source()
+    self._apply_source(source)
+    await self._refresh_volume()
+    await self._refresh_mute()
+
+  def _apply_source(self, source):
+    if source:
+      self._current_source = source['mode']
+      self._mode = source['submode'] or ''
+    else:
+      self._mode = ''
+
+  async def _refresh_volume(self):
+    try:
       volume = await self.api.get_volume()
-      if volume:
+      if volume and volume[0]:
         self._volume = int(volume[0]) / self._max_volume
-      "Get Mute State"
-      muted = await self.api.get_muted()
-      if muted:
-        self._muted = muted
+    except Exception:
+      _LOGGER.error("Failed to get volume")
+
+  async def _refresh_mute(self):
+    muted = await self.api.get_muted()
+    if muted:
+      self._muted = muted
+
+  async def _refresh_media_info(self):
+    title = await self.api.get_radio_info()
+    if title:
+      self._media_title = str(title[0])
+    image = await self.api.get_radio_image()
+    if image:
+      self._image_url = str(image[0])
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Samsung MultiRoom platform asynchronously."""

--- a/custom_components/samsung_soundbar/media_player.py
+++ b/custom_components/samsung_soundbar/media_player.py
@@ -102,6 +102,26 @@ class MultiRoomApi():
       _LOGGER.debug("exception")
       return None
 
+  async def _exec_get_xml(self, mode, action, expected_method, retries=3, timeout=TIMEOUT):
+    for attempt in range(retries):
+      data = await self._exec_cmd(mode, '<name>{0}</name>'.format(action), timeout=timeout)
+      if not data:
+        return None
+      try:
+        parsed = xmltodict.parse(data)
+        node = parsed.get(mode, {})
+        if node.get('method') != expected_method:
+          _LOGGER.debug("_exec_get_xml: expected method %s, got %s (attempt %d/%d)", expected_method, node.get('method'), attempt + 1, retries)
+          continue
+        response = node.get('response', {})
+        if response.get('@result') != 'ok':
+          return None
+        return response
+      except Exception:
+        return None
+    _LOGGER.warning("_exec_get_xml: no %s response after %d attempts", expected_method, retries)
+    return None
+
   async def _exec_get(self, mode, action, key_to_extract):
     return await self._exec_cmd_legacy(mode, '<name>{0}</name>'.format(action), key_to_extract)
 

--- a/custom_components/samsung_soundbar/media_player.py
+++ b/custom_components/samsung_soundbar/media_player.py
@@ -4,6 +4,7 @@ import aiohttp
 import asyncio
 import re
 import logging
+import xmltodict
 import voluptuous as vol
 import homeassistant.util as util
 
@@ -70,8 +71,21 @@ class MultiRoomApi():
     self.port = port
     self.endpoint = 'http://{0}:{1}'.format(ip, port)
 
-  async def _exec_cmd(self, mode ,cmd, key_to_extract):
-    import xmltodict
+  async def _exec_cmd(self, mode, cmd):
+    query = urllib.parse.urlencode({ "cmd": cmd }, quote_via=urllib.parse.quote)
+    url = '{0}/{1}?{2}'.format(self.endpoint, mode, query)
+    try:
+      async with async_timeout.timeout(TIMEOUT):
+        _LOGGER.debug("Executing: {} with cmd: {}".format(url, cmd))
+        response = await self.session.get(url)
+        data = await response.text()
+        _LOGGER.debug(data)
+        return data or None
+    except:
+      _LOGGER.debug("exception")
+      return None
+
+  async def _exec_cmd_legacy(self, mode, cmd, key_to_extract):
     query = urllib.parse.urlencode({ "cmd": cmd }, quote_via=urllib.parse.quote)
     url = '{0}/{1}?{2}'.format(self.endpoint, mode, query)
 
@@ -89,7 +103,7 @@ class MultiRoomApi():
       return None
 
   async def _exec_get(self, mode, action, key_to_extract):
-    return await self._exec_cmd(mode, '<name>{0}</name>'.format(action), key_to_extract)
+    return await self._exec_cmd_legacy(mode, '<name>{0}</name>'.format(action), key_to_extract)
 
   async def _exec_set(self, mode, action, property_name, value):
     if type(value) is str:
@@ -97,7 +111,7 @@ class MultiRoomApi():
     else:
       value_type = 'dec'
     cmd = '<name>{0}</name><p type="{3}" name="{1}" val="{2}"/>'.format(action, property_name, value, value_type)
-    return await self._exec_cmd(mode, cmd, property_name)
+    return await self._exec_cmd_legacy(mode, cmd, property_name)
 
   async def _exec_play(self, mode, action, property_name, value, p2, v2):
     if type(value) is str:
@@ -105,7 +119,7 @@ class MultiRoomApi():
     else:
       value_type = 'dec'
     cmd = '<name>{0}</name><p type="{3}" name="{1}" val="{2}"/><p type="{3}" name="{4}" val="{5}"/>'.format(action, property_name, value, value_type, p2, v2)
-    return await self._exec_cmd(mode, cmd, property_name)
+    return await self._exec_cmd_legacy(mode, cmd, property_name)
 
   async def get_state(self):
     result = await self._exec_get('UIC','GetPowerStatus', '<powerStatus>(.*?)</powerStatus>')
@@ -145,21 +159,23 @@ class MultiRoomApi():
 
   async def get_source(self):
     "res[0] = source ; res[1] = mode"
-    res = []
-    result = await self._exec_get('UIC','GetFunc', '<response result="ok">(.*?)</response>')
-    if result:
-      function = re.findall('<function>(.*?)</function>',result[0])[0]
-      res.append(function)
+    data = await self._exec_cmd('UIC', '<name>GetFunc</name>')
+    if not data:
+      return None
+    try:
+      parsed = xmltodict.parse(data)
+      response = parsed.get('UIC', {}).get('response', {})
+      if response.get('@result') != 'ok':
+        return None
+      function = response.get('function')
+      if function is None:
+        return None
       if function == 'bt':
-        res.append(False)
-      else:
-        mode = re.findall('<submode>(.*?)</submode>',result[0])
-        if mode and mode[0] == 'cp':
-          res.append('TuneIn')
-        else:
-          res.append(False)
-      return res
-    return None
+        return [function, False]
+      submode = response.get('submode')
+      return [function, 'TuneIn' if submode == 'cp' else False]
+    except Exception:
+      return None
 
   async def set_source(self, source):
     SEPARATOR = ' - '

--- a/custom_components/samsung_soundbar/media_player.py
+++ b/custom_components/samsung_soundbar/media_player.py
@@ -158,7 +158,6 @@ class MultiRoomApi():
       await self._exec_set('UIC','SetMute', 'mute', BOOL_OFF)
 
   async def get_source(self):
-    "res[0] = source ; res[1] = mode"
     data = await self._exec_cmd('UIC', '<name>GetFunc</name>')
     if not data:
       return None
@@ -171,9 +170,9 @@ class MultiRoomApi():
       if function is None:
         return None
       if function == 'bt':
-        return [function, False]
+        return {'mode': function, 'submode': False}
       submode = response.get('submode')
-      return [function, 'TuneIn' if submode == 'cp' else False]
+      return {'mode': function, 'submode': 'TuneIn' if submode == 'cp' else False}
     except Exception:
       return None
 
@@ -299,12 +298,10 @@ class MultiRoomDevice(MediaPlayerEntity):
         "Get Current Source"
         source = await self.api.get_source()
         if source is not None:
-          "Source 0 is type on input"
-          if source[0]:
-            self._current_source = source[0]
-          "Source 1 is input mode"
-          if source[1]:
-            self._mode = source[1]
+          if source['mode']:
+            self._current_source = source['mode']
+          if source['submode']:
+            self._mode = source['submode']
           else:
             self._mode = ''
         else:
@@ -341,7 +338,7 @@ class MultiRoomDevice(MediaPlayerEntity):
       "Get Current Source"
       source = await self.api.get_source()
       if source:
-        self._current_source = source[0]
+        self._current_source = source['mode']
         self._state = STATE_ON
       else:
         self._state = STATE_OFF

--- a/custom_components/samsung_soundbar/media_player.py
+++ b/custom_components/samsung_soundbar/media_player.py
@@ -163,7 +163,13 @@ class MultiRoomApi():
       return None
     try:
       parsed = xmltodict.parse(data)
-      response = parsed.get('UIC', {}).get('response', {})
+      uic = parsed.get('UIC', {})
+      # When in WiFi mode, GetFunc may return a non-CurrentFunc response (e.g. VolumeLevel,
+      # PowerStatus) instead of a CurrentFunc response with a <function> element.
+      # This seems to only happen in WiFi mode, so just assume that's the state.
+      if uic.get('method') != 'CurrentFunc':
+        return {'mode': 'wifi', 'submode': False}
+      response = uic.get('response', {})
       if response.get('@result') != 'ok':
         return None
       function = response.get('function')

--- a/custom_components/samsung_soundbar/strings.json
+++ b/custom_components/samsung_soundbar/strings.json
@@ -1,0 +1,22 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Set up Samsung Soundbar",
+        "data": {
+          "host": "Host",
+          "name": "Name",
+          "port": "Port",
+          "max_volume": "Max Volume",
+          "power_options": "Enable Power Control"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect to the soundbar. Verify the host and port."
+    },
+    "abort": {
+      "already_configured": "This soundbar is already configured."
+    }
+  }
+}

--- a/custom_components/samsung_soundbar/strings.json
+++ b/custom_components/samsung_soundbar/strings.json
@@ -1,6 +1,11 @@
 {
   "config": {
+    "title": "Samsung Soundbar",
     "step": {
+      "confirm": {
+        "title": "Confirm Samsung Soundbar",
+        "description": "Found **{name}** at `{host}`. Do you want to add it?"
+      },
       "user": {
         "title": "Set up Samsung Soundbar",
         "data": {
@@ -16,7 +21,8 @@
       "cannot_connect": "Failed to connect to the soundbar. Verify the host and port."
     },
     "abort": {
-      "already_configured": "This soundbar is already configured."
+      "already_configured": "This soundbar is already configured.",
+      "not_samsung_soundbar": "The discovered device is not a Samsung WAM soundbar."
     }
   }
 }

--- a/custom_components/samsung_soundbar/translations/en.json
+++ b/custom_components/samsung_soundbar/translations/en.json
@@ -1,0 +1,22 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Set up Samsung Soundbar",
+        "data": {
+          "host": "Host",
+          "name": "Name",
+          "port": "Port",
+          "max_volume": "Max Volume",
+          "power_options": "Enable Power Control"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect to the soundbar. Verify the host and port."
+    },
+    "abort": {
+      "already_configured": "This soundbar is already configured."
+    }
+  }
+}

--- a/custom_components/samsung_soundbar/translations/en.json
+++ b/custom_components/samsung_soundbar/translations/en.json
@@ -1,6 +1,11 @@
 {
   "config": {
+    "title": "Samsung Soundbar",
     "step": {
+      "confirm": {
+        "title": "Confirm Samsung Soundbar",
+        "description": "Found **{name}** at `{host}`. Do you want to add it?"
+      },
       "user": {
         "title": "Set up Samsung Soundbar",
         "data": {
@@ -16,7 +21,8 @@
       "cannot_connect": "Failed to connect to the soundbar. Verify the host and port."
     },
     "abort": {
-      "already_configured": "This soundbar is already configured."
+      "already_configured": "This soundbar is already configured.",
+      "not_samsung_soundbar": "The discovered device is not a Samsung WAM soundbar."
     }
   }
 }

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Test configuration for Samsung Soundbar."""
+import pytest
+
+pytest_plugins = "pytest_homeassistant_custom_component"
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+  """Enable custom integrations for all tests."""
+  yield

--- a/tests/test_airplay_detect.py
+++ b/tests/test_airplay_detect.py
@@ -1,0 +1,193 @@
+"""Tests for AirPlay detection via mDNS unicast probe."""
+import asyncio
+import struct
+
+from unittest.mock import MagicMock, patch
+
+from custom_components.samsung_soundbar.airplay_detect import is_airplay_active
+
+_RAOP_SERVICE = "_raop._tcp.local"
+_INSTANCE_NAME = "AABBCCDDEEFF@MySoundbar._raop._tcp.local"
+
+
+# ---------------------------------------------------------------------------
+# DNS packet helpers
+# ---------------------------------------------------------------------------
+
+def _encode_name(name: str) -> bytes:
+    result = b""
+    for label in name.rstrip(".").split("."):
+        enc = label.encode()
+        result += bytes([len(enc)]) + enc
+    return result + b"\x00"
+
+
+def _build_ptr_response(service: str, instance: str) -> bytes:
+    """Build a minimal one-answer DNS PTR response packet."""
+    encoded_service = _encode_name(service)
+    encoded_instance = _encode_name(instance)
+    header = struct.pack(">HHHHHH", 0x0001, 0x8400, 0, 1, 0, 0)
+    answer = encoded_service + struct.pack(">HHIH", 12, 1, 4500, len(encoded_instance)) + encoded_instance
+    return header + answer
+
+
+def _build_txt_response(name: str, txt_fields: dict) -> bytes:
+    """Build a minimal one-answer DNS TXT response packet."""
+    rdata = b""
+    for k, v in txt_fields.items():
+        item = f"{k}={v}".encode()
+        rdata += bytes([len(item)]) + item
+
+    encoded_name = _encode_name(name)
+    header = struct.pack(">HHHHHH", 0x0001, 0x8400, 0, 1, 0, 0)
+    answer = encoded_name + struct.pack(">HHIH", 16, 1, 4500, len(rdata)) + rdata
+    return header + answer
+
+
+def _endpoint_mock(loop, *responses):
+    """
+    Return an async callable that mimics loop.create_datagram_endpoint.
+
+    responses[i] is delivered to the protocol on the i-th call. If a call
+    index exceeds the list, no data is delivered (simulates timeout).
+    """
+    responses = list(responses)
+    calls = []
+
+    async def fake(protocol_factory, *, remote_addr=None, **kwargs):
+        idx = len(calls)
+        calls.append(idx)
+        response_data = responses[idx] if idx < len(responses) else None
+        protocol = protocol_factory()
+        transport = MagicMock()
+        protocol.connection_made(transport)
+        if response_data is not None:
+            addr = (remote_addr[0] if remote_addr else "0.0.0.0", 5353)
+            loop.call_soon(protocol.datagram_received, response_data, addr)
+        return transport, protocol
+
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# Two-step happy path
+# ---------------------------------------------------------------------------
+
+async def test_airplay_active_sf_session_bit_set():
+    """PTR → TXT with sf=0x0804 (bit 0x0800 set) → True."""
+    loop = asyncio.get_running_loop()
+    ptr_resp = _build_ptr_response(_RAOP_SERVICE, _INSTANCE_NAME)
+    txt_resp = _build_txt_response(_INSTANCE_NAME, {"sf": "0x804"})
+    with patch.object(loop, "create_datagram_endpoint",
+                      side_effect=_endpoint_mock(loop, ptr_resp, txt_resp)):
+        result = await is_airplay_active("192.168.1.100")
+    assert result is True
+
+
+async def test_airplay_inactive_sf_session_bit_clear():
+    """PTR → TXT with sf=0x0004 (bit 0x0800 clear) → False."""
+    loop = asyncio.get_running_loop()
+    ptr_resp = _build_ptr_response(_RAOP_SERVICE, _INSTANCE_NAME)
+    txt_resp = _build_txt_response(_INSTANCE_NAME, {"sf": "0x4"})
+    with patch.object(loop, "create_datagram_endpoint",
+                      side_effect=_endpoint_mock(loop, ptr_resp, txt_resp)):
+        result = await is_airplay_active("192.168.1.100")
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Step 1 (PTR) failures
+# ---------------------------------------------------------------------------
+
+async def test_step1_timeout_returns_false():
+    """No response to PTR query → returns False without raising."""
+    loop = asyncio.get_running_loop()
+    with patch.object(loop, "create_datagram_endpoint",
+                      side_effect=_endpoint_mock(loop)):
+        result = await is_airplay_active("192.168.1.100", timeout=0.05)
+    assert result is False
+
+
+async def test_step1_no_ptr_records_returns_false():
+    """Step 1 response contains only TXT (wrong type) — no PTR → False."""
+    loop = asyncio.get_running_loop()
+    txt_only = _build_txt_response(_RAOP_SERVICE, {"sf": "0x804"})
+    with patch.object(loop, "create_datagram_endpoint",
+                      side_effect=_endpoint_mock(loop, txt_only)):
+        result = await is_airplay_active("192.168.1.100")
+    assert result is False
+
+
+async def test_step1_ptr_wrong_service_returns_false():
+    """PTR record in step 1 points to a non-RAOP service → False."""
+    loop = asyncio.get_running_loop()
+    ptr_resp = _build_ptr_response("_airplay._tcp.local",
+                                   "AABBCCDDEEFF@MySoundbar._airplay._tcp.local")
+    with patch.object(loop, "create_datagram_endpoint",
+                      side_effect=_endpoint_mock(loop, ptr_resp)):
+        result = await is_airplay_active("192.168.1.100")
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Step 2 (TXT) failures
+# ---------------------------------------------------------------------------
+
+async def test_step2_timeout_returns_false():
+    """PTR succeeds but TXT query times out → False."""
+    loop = asyncio.get_running_loop()
+    ptr_resp = _build_ptr_response(_RAOP_SERVICE, _INSTANCE_NAME)
+    # Only one response supplied; second _probe call gets no data → timeout.
+    with patch.object(loop, "create_datagram_endpoint",
+                      side_effect=_endpoint_mock(loop, ptr_resp)):
+        result = await is_airplay_active("192.168.1.100", timeout=0.1)
+    assert result is False
+
+
+async def test_step2_no_sf_field_returns_false():
+    """Step 2 TXT record has no sf key → False."""
+    loop = asyncio.get_running_loop()
+    ptr_resp = _build_ptr_response(_RAOP_SERVICE, _INSTANCE_NAME)
+    txt_resp = _build_txt_response(_INSTANCE_NAME, {"pk": "abcd1234"})
+    with patch.object(loop, "create_datagram_endpoint",
+                      side_effect=_endpoint_mock(loop, ptr_resp, txt_resp)):
+        result = await is_airplay_active("192.168.1.100")
+    assert result is False
+
+
+async def test_step2_sf_not_valid_hex_returns_false():
+    """sf value that cannot be parsed as hex → False without raising."""
+    loop = asyncio.get_running_loop()
+    ptr_resp = _build_ptr_response(_RAOP_SERVICE, _INSTANCE_NAME)
+    txt_resp = _build_txt_response(_INSTANCE_NAME, {"sf": "not-a-hex"})
+    with patch.object(loop, "create_datagram_endpoint",
+                      side_effect=_endpoint_mock(loop, ptr_resp, txt_resp)):
+        result = await is_airplay_active("192.168.1.100")
+    assert result is False
+
+
+async def test_step2_txt_wrong_service_returns_false():
+    """Step 2 TXT record name does not contain _raop._tcp → False."""
+    loop = asyncio.get_running_loop()
+    ptr_resp = _build_ptr_response(_RAOP_SERVICE, _INSTANCE_NAME)
+    txt_resp = _build_txt_response("_airplay._tcp.local", {"sf": "0x804"})
+    with patch.object(loop, "create_datagram_endpoint",
+                      side_effect=_endpoint_mock(loop, ptr_resp, txt_resp)):
+        result = await is_airplay_active("192.168.1.100")
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Transport / network errors
+# ---------------------------------------------------------------------------
+
+async def test_oserror_on_step1_returns_false():
+    """OSError when opening the UDP socket → returns False without raising."""
+    loop = asyncio.get_running_loop()
+
+    async def raise_oserror(*args, **kwargs):
+        raise OSError("Network unreachable")
+
+    with patch.object(loop, "create_datagram_endpoint", side_effect=raise_oserror):
+        result = await is_airplay_active("192.168.1.100")
+    assert result is False

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2,6 +2,7 @@
 from unittest.mock import AsyncMock, patch
 
 from homeassistant import config_entries
+from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
 from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -141,6 +142,93 @@ async def test_user_flow_duplicate_device(hass):
   ):
     result = await hass.config_entries.flow.async_configure(
       result["flow_id"], USER_INPUT
+    )
+
+  assert result["type"] == FlowResultType.ABORT
+  assert result["reason"] == "already_configured"
+
+
+SSDP_DISCOVERY_INFO = SsdpServiceInfo(
+  ssdp_usn="uuid:abc123",
+  ssdp_st="urn:schemas-upnp-org:device:MediaRenderer:1",
+  upnp={"manufacturer": "Samsung Electronics"},
+  ssdp_location="http://192.168.1.100:56001/description.xml",
+)
+
+
+async def test_ssdp_flow_shows_confirm(hass):
+  """Test that SSDP discovery shows the confirm form."""
+  with patch(
+    "custom_components.samsung_soundbar.config_flow.MultiRoomApi.get_speaker_name",
+    new_callable=AsyncMock,
+    return_value=["My Soundbar"],
+  ):
+    result = await hass.config_entries.flow.async_init(
+      DOMAIN,
+      context={"source": config_entries.SOURCE_SSDP},
+      data=SSDP_DISCOVERY_INFO,
+    )
+
+  assert result["type"] == FlowResultType.FORM
+  assert result["step_id"] == "confirm"
+
+
+async def test_ssdp_flow_confirm_creates_entry(hass):
+  """Test that confirming a discovered device creates a config entry."""
+  with patch(
+    "custom_components.samsung_soundbar.config_flow.MultiRoomApi.get_speaker_name",
+    new_callable=AsyncMock,
+    return_value=["My Soundbar"],
+  ):
+    result = await hass.config_entries.flow.async_init(
+      DOMAIN,
+      context={"source": config_entries.SOURCE_SSDP},
+      data=SSDP_DISCOVERY_INFO,
+    )
+
+  result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+  assert result["type"] == FlowResultType.CREATE_ENTRY
+  assert result["title"] == "My Soundbar"
+  assert result["data"][CONF_HOST] == "192.168.1.100"
+  assert result["data"][CONF_NAME] == "My Soundbar"
+
+
+async def test_ssdp_flow_not_samsung_soundbar(hass):
+  """Test that a non-soundbar device aborts with not_samsung_soundbar."""
+  with patch(
+    "custom_components.samsung_soundbar.config_flow.MultiRoomApi.get_speaker_name",
+    new_callable=AsyncMock,
+    return_value=None,
+  ):
+    result = await hass.config_entries.flow.async_init(
+      DOMAIN,
+      context={"source": config_entries.SOURCE_SSDP},
+      data=SSDP_DISCOVERY_INFO,
+    )
+
+  assert result["type"] == FlowResultType.ABORT
+  assert result["reason"] == "not_samsung_soundbar"
+
+
+async def test_ssdp_flow_already_configured(hass):
+  """Test that a duplicate SSDP discovery aborts with already_configured."""
+  entry = MockConfigEntry(
+    domain=DOMAIN,
+    unique_id=f"192.168.1.100:{DEFAULT_PORT}",
+    data={CONF_HOST: "192.168.1.100"},
+  )
+  entry.add_to_hass(hass)
+
+  with patch(
+    "custom_components.samsung_soundbar.config_flow.MultiRoomApi.get_speaker_name",
+    new_callable=AsyncMock,
+    return_value=["My Soundbar"],
+  ):
+    result = await hass.config_entries.flow.async_init(
+      DOMAIN,
+      context={"source": config_entries.SOURCE_SSDP},
+      data=SSDP_DISCOVERY_INFO,
     )
 
   assert result["type"] == FlowResultType.ABORT

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,147 @@
+"""Tests for Samsung Soundbar config flow."""
+from unittest.mock import AsyncMock, patch
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.data_entry_flow import FlowResultType
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.samsung_soundbar.const import (
+  DOMAIN,
+  DEFAULT_NAME,
+  DEFAULT_PORT,
+  DEFAULT_MAX_VOLUME,
+  DEFAULT_POWER_OPTIONS,
+  CONF_PORT,
+  CONF_MAX_VOLUME,
+  CONF_POWER_OPTIONS,
+)
+
+
+USER_INPUT = {
+  CONF_HOST: "192.168.1.100",
+  CONF_NAME: "Living Room Soundbar",
+  CONF_PORT: DEFAULT_PORT,
+  CONF_MAX_VOLUME: int(DEFAULT_MAX_VOLUME),
+  CONF_POWER_OPTIONS: DEFAULT_POWER_OPTIONS,
+}
+
+
+async def test_user_flow_shows_form(hass):
+  """Test that the user flow shows a form on first step."""
+  result = await hass.config_entries.flow.async_init(
+    DOMAIN, context={"source": config_entries.SOURCE_USER}
+  )
+  assert result["type"] == FlowResultType.FORM
+  assert result["step_id"] == "user"
+  assert result["errors"] == {}
+
+
+async def test_user_flow_success(hass):
+  """Test a successful user setup flow creates a config entry."""
+  result = await hass.config_entries.flow.async_init(
+    DOMAIN, context={"source": config_entries.SOURCE_USER}
+  )
+
+  with patch(
+    "custom_components.samsung_soundbar.config_flow.MultiRoomApi.get_speaker_name",
+    new_callable=AsyncMock,
+    return_value=["My Soundbar"],
+  ):
+    result = await hass.config_entries.flow.async_configure(
+      result["flow_id"], USER_INPUT
+    )
+
+  assert result["type"] == FlowResultType.CREATE_ENTRY
+  assert result["title"] == USER_INPUT[CONF_NAME]
+  assert result["data"][CONF_HOST] == USER_INPUT[CONF_HOST]
+  assert result["data"][CONF_PORT] == USER_INPUT[CONF_PORT]
+  assert result["data"][CONF_MAX_VOLUME] == USER_INPUT[CONF_MAX_VOLUME]
+  assert result["data"][CONF_POWER_OPTIONS] == USER_INPUT[CONF_POWER_OPTIONS]
+
+
+async def test_user_flow_cannot_connect(hass):
+  """Test that a connection failure shows an error and re-displays the form."""
+  result = await hass.config_entries.flow.async_init(
+    DOMAIN, context={"source": config_entries.SOURCE_USER}
+  )
+
+  with patch(
+    "custom_components.samsung_soundbar.config_flow.MultiRoomApi.get_speaker_name",
+    new_callable=AsyncMock,
+    return_value=None,
+  ):
+    result = await hass.config_entries.flow.async_configure(
+      result["flow_id"], USER_INPUT
+    )
+
+  assert result["type"] == FlowResultType.FORM
+  assert result["step_id"] == "user"
+  assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_user_flow_max_volume_stored(hass):
+  """Test that a nonzero max_volume value is stored in the entry."""
+  result = await hass.config_entries.flow.async_init(
+    DOMAIN, context={"source": config_entries.SOURCE_USER}
+  )
+
+  with patch(
+    "custom_components.samsung_soundbar.config_flow.MultiRoomApi.get_speaker_name",
+    new_callable=AsyncMock,
+    return_value=["My Soundbar"],
+  ):
+    result = await hass.config_entries.flow.async_configure(
+      result["flow_id"],
+      {**USER_INPUT, CONF_MAX_VOLUME: 25},
+    )
+
+  assert result["type"] == FlowResultType.CREATE_ENTRY
+  assert result["data"][CONF_MAX_VOLUME] == 25
+
+
+async def test_user_flow_max_volume_zero_stored(hass):
+  """Test that max_volume=0 (no limit) is stored as-is."""
+  result = await hass.config_entries.flow.async_init(
+    DOMAIN, context={"source": config_entries.SOURCE_USER}
+  )
+
+  with patch(
+    "custom_components.samsung_soundbar.config_flow.MultiRoomApi.get_speaker_name",
+    new_callable=AsyncMock,
+    return_value=["My Soundbar"],
+  ):
+    result = await hass.config_entries.flow.async_configure(
+      result["flow_id"],
+      {**USER_INPUT, CONF_MAX_VOLUME: 0},
+    )
+
+  assert result["type"] == FlowResultType.CREATE_ENTRY
+  assert result["data"][CONF_MAX_VOLUME] == 0
+
+
+async def test_user_flow_duplicate_device(hass):
+  """Test that configuring a duplicate host aborts with already_configured."""
+  entry = MockConfigEntry(
+    domain=DOMAIN,
+    unique_id=f"{USER_INPUT[CONF_HOST]}:{USER_INPUT[CONF_PORT]}",
+    data={CONF_HOST: USER_INPUT[CONF_HOST]},
+  )
+  entry.add_to_hass(hass)
+
+  result = await hass.config_entries.flow.async_init(
+    DOMAIN, context={"source": config_entries.SOURCE_USER}
+  )
+
+  with patch(
+    "custom_components.samsung_soundbar.config_flow.MultiRoomApi.get_speaker_name",
+    new_callable=AsyncMock,
+    return_value=["My Soundbar"],
+  ):
+    result = await hass.config_entries.flow.async_configure(
+      result["flow_id"], USER_INPUT
+    )
+
+  assert result["type"] == FlowResultType.ABORT
+  assert result["reason"] == "already_configured"

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -1,0 +1,123 @@
+"""Tests for Samsung Soundbar media player setup."""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.const import CONF_HOST, CONF_NAME
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.samsung_soundbar.const import (
+  DOMAIN,
+  DEFAULT_NAME,
+  DEFAULT_PORT,
+  DEFAULT_MAX_VOLUME,
+  DEFAULT_POWER_OPTIONS,
+  CONF_PORT,
+  CONF_MAX_VOLUME,
+  CONF_POWER_OPTIONS,
+)
+
+BASE_ENTRY_DATA = {
+  CONF_HOST: "192.168.1.100",
+  CONF_NAME: DEFAULT_NAME,
+  CONF_PORT: DEFAULT_PORT,
+  CONF_MAX_VOLUME: int(DEFAULT_MAX_VOLUME),
+  CONF_POWER_OPTIONS: DEFAULT_POWER_OPTIONS,
+}
+
+BASE_YAML_CONFIG = {
+  CONF_HOST: "192.168.1.100",
+  CONF_NAME: DEFAULT_NAME,
+  CONF_PORT: DEFAULT_PORT,
+  CONF_MAX_VOLUME: DEFAULT_MAX_VOLUME,  # string, as YAML delivers it
+  CONF_POWER_OPTIONS: DEFAULT_POWER_OPTIONS,
+}
+
+
+async def _setup_entry(hass, data):
+  """Helper: set up a config entry and return the created entities."""
+  entry = MockConfigEntry(domain=DOMAIN, unique_id=data[CONF_HOST], data=data)
+  entities = []
+
+  with patch("custom_components.samsung_soundbar.media_player.async_get_clientsession"):
+    from custom_components.samsung_soundbar.media_player import async_setup_entry
+    await async_setup_entry(hass, entry, lambda e, *_: entities.extend(e))
+
+  return entities
+
+
+async def _setup_platform(hass, config):
+  """Helper: set up via YAML platform path and return the created entities."""
+  entities = []
+
+  with patch("custom_components.samsung_soundbar.media_player.async_get_clientsession"):
+    from custom_components.samsung_soundbar.media_player import async_setup_platform
+    await async_setup_platform(hass, config, lambda e, *_: entities.extend(e))
+
+  return entities
+
+
+# --- Config entry (UI) path ---
+
+async def test_max_volume_applied_when_nonzero(hass):
+  """When max_volume is between 1-99, the entity uses that value."""
+  entities = await _setup_entry(hass, {**BASE_ENTRY_DATA, CONF_MAX_VOLUME: 25})
+  assert entities[0]._max_volume == 25
+
+
+async def test_max_volume_100_when_zero(hass):
+  """When max_volume is 0 (no limit), the entity uses 100."""
+  entities = await _setup_entry(hass, {**BASE_ENTRY_DATA, CONF_MAX_VOLUME: 0})
+  assert entities[0]._max_volume == 100
+
+
+async def test_max_volume_100_when_100(hass):
+  """When max_volume is 100 (no limit), the entity uses 100."""
+  entities = await _setup_entry(hass, {**BASE_ENTRY_DATA, CONF_MAX_VOLUME: 100})
+  assert entities[0]._max_volume == 100
+
+
+# --- YAML platform path ---
+
+async def test_yaml_max_volume_applied(hass):
+  """YAML setup uses the configured max_volume string value."""
+  entities = await _setup_platform(hass, {**BASE_YAML_CONFIG, CONF_MAX_VOLUME: "25"})
+  assert entities[0]._max_volume == 25
+
+
+async def test_yaml_set_volume_scales_by_max_volume(hass):
+  """set_volume_level sends volume * max_volume to the device."""
+  entities = await _setup_platform(hass, {**BASE_YAML_CONFIG, CONF_MAX_VOLUME: "40"})
+  entity = entities[0]
+  entity.api.set_volume = AsyncMock()
+
+  await entity.async_set_volume_level(0.5)
+
+  entity.api.set_volume.assert_called_once_with(20.0)
+
+
+async def test_yaml_update_scales_volume_from_device(hass):
+  """async_update divides raw device volume by the default max_volume (40)."""
+  entities = await _setup_platform(hass, BASE_YAML_CONFIG)
+  entity = entities[0]
+  entity.api.get_state = AsyncMock(return_value="1")
+  entity.api.get_source = AsyncMock(return_value=["hdmi1", False])
+  entity.api.get_volume = AsyncMock(return_value=["10"])
+  entity.api.get_muted = AsyncMock(return_value=False)
+
+  await entity.async_update()
+
+  assert entity._volume == 0.25
+
+
+async def test_yaml_update_scales_volume_from_device_nondefault_max(hass):
+  """async_update scaling works correctly with a non-default max_volume."""
+  entities = await _setup_platform(hass, {**BASE_YAML_CONFIG, CONF_MAX_VOLUME: "60"})
+  entity = entities[0]
+  entity.api.get_state = AsyncMock(return_value="1")
+  entity.api.get_source = AsyncMock(return_value=["hdmi1", False])
+  entity.api.get_volume = AsyncMock(return_value=["15"])
+  entity.api.get_muted = AsyncMock(return_value=False)
+
+  await entity.async_update()
+
+  assert entity._volume == 0.25

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -1,6 +1,8 @@
 """Tests for Samsung Soundbar media player setup."""
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from custom_components.samsung_soundbar.media_player import MultiRoomApi
+
 from homeassistant.const import CONF_HOST, CONF_NAME
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -108,6 +110,30 @@ async def test_yaml_update_scales_volume_from_device(hass):
 
   assert entity._volume == 0.25
 
+
+# --- MultiRoomApi ---
+
+def _make_api(xml_response):
+  """Return a MultiRoomApi whose session returns the given XML string."""
+  mock_response = MagicMock()
+  mock_response.text = AsyncMock(return_value=xml_response)
+  session = MagicMock()
+  session.get = AsyncMock(return_value=mock_response)
+  return MultiRoomApi("192.168.1.100", "56001", session, None)
+
+
+async def test_get_speaker_name_plain(hass):
+  """get_speaker_name returns the name when it is a plain string."""
+  api = _make_api("<UIC><response result='ok'><spkname>Office Soundbar</spkname></response></UIC>")
+  result = await api.get_speaker_name()
+  assert result == ["Office Soundbar"]
+
+
+async def test_get_speaker_name_cdata(hass):
+  """get_speaker_name strips CDATA wrapper and returns the bare name."""
+  api = _make_api("<UIC><response result='ok'><spkname><![CDATA[Office Soundbar]]></spkname></response></UIC>")
+  result = await api.get_speaker_name()
+  assert result == ["Office Soundbar"]
 
 async def test_yaml_update_scales_volume_from_device_nondefault_max(hass):
   """async_update scaling works correctly with a non-default max_volume."""

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -279,10 +279,28 @@ async def test_get_source_wifi_other_submode(hass):
   assert result == {'mode': 'wifi', 'submode': False}
 
 
-async def test_get_source_wifi_non_currentfunc_response(hass):
-  """get_source infers wifi when GetFunc returns any non-CurrentFunc response."""
-  api = _make_api('<UIC><method>VolumeLevel</method><version>1.0</version><response result="ok"><volume>10</volume></response></UIC>')
-  result = await api.get_source()
+async def test_get_source_wifi_on_exhausted_retries():
+  """get_source falls back to wifi after all retries return push events instead of CurrentFunc."""
+  api = MultiRoomApi("192.168.1.100", "56001", MagicMock(), None)
+  with patch.object(api, '_exec_cmd', AsyncMock(side_effect=[PUSH_XML, PUSH_XML, PUSH_XML])):
+    result = await api.get_source()
+  assert result == {'mode': 'wifi', 'submode': False}
+
+
+async def test_get_source_retries_past_push_event():
+  """get_source discards a push event and succeeds on the next attempt."""
+  good = '<UIC><method>CurrentFunc</method><response result="ok"><function>hdmi1</function><submode></submode></response></UIC>'
+  api = MultiRoomApi("192.168.1.100", "56001", MagicMock(), None)
+  with patch.object(api, '_exec_cmd', AsyncMock(side_effect=[PUSH_XML, good])):
+    result = await api.get_source()
+  assert result == {'mode': 'hdmi1', 'submode': False}
+
+
+async def test_get_source_wifi_on_push_then_timeout():
+  """get_source falls back to wifi when a push event is followed by a timeout (None)."""
+  api = MultiRoomApi("192.168.1.100", "56001", MagicMock(), None)
+  with patch.object(api, '_exec_cmd', AsyncMock(side_effect=[PUSH_XML, None])):
+    result = await api.get_source()
   assert result == {'mode': 'wifi', 'submode': False}
 
 

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -122,6 +122,79 @@ def _make_api(xml_response):
   return MultiRoomApi("192.168.1.100", "56001", session, None)
 
 
+def _make_api_multi(xml_responses):
+  """Return a MultiRoomApi whose session yields xml_responses in sequence."""
+  mock_response = MagicMock()
+  mock_response.text = AsyncMock(side_effect=xml_responses)
+  session = MagicMock()
+  session.get = AsyncMock(return_value=mock_response)
+  return MultiRoomApi("192.168.1.100", "56001", session, None)
+
+
+# --- _exec_get_xml ---
+
+VOLUME_XML = '<UIC><method>VolumeLevel</method><response result="ok"><volume>10</volume></response></UIC>'
+POWER_XML  = '<UIC><method>PowerStatus</method><response result="ok"><powerStatus>1</powerStatus></response></UIC>'
+PUSH_XML   = '<UIC><method>PowerStatus</method><response result="ok"><powerStatus>1</powerStatus></response></UIC>'
+
+
+async def test_exec_get_xml_happy_path():
+  """Returns the response dict when the method matches on the first attempt."""
+  api = _make_api(VOLUME_XML)
+  result = await api._exec_get_xml('UIC', 'GetVolume', 'VolumeLevel')
+  assert result == {'@result': 'ok', 'volume': '10'}
+
+
+async def test_exec_get_xml_no_data():
+  """Returns None immediately when _exec_cmd returns no data (e.g. timeout)."""
+  api = _make_api_multi([None])
+  with patch.object(api, '_exec_cmd', AsyncMock(return_value=None)):
+    result = await api._exec_get_xml('UIC', 'GetVolume', 'VolumeLevel')
+  assert result is None
+
+
+async def test_exec_get_xml_parse_exception():
+  """Returns None when the response is not valid XML."""
+  api = _make_api("not xml at all")
+  result = await api._exec_get_xml('UIC', 'GetVolume', 'VolumeLevel')
+  assert result is None
+
+
+async def test_exec_get_xml_wrong_result():
+  """Returns None when the response result is not 'ok'."""
+  api = _make_api('<UIC><method>VolumeLevel</method><response result="ng"><volume>10</volume></response></UIC>')
+  result = await api._exec_get_xml('UIC', 'GetVolume', 'VolumeLevel')
+  assert result is None
+
+
+async def test_exec_get_xml_retry_on_wrong_method():
+  """Retries when the first response has the wrong method, succeeds on the second."""
+  api = _make_api_multi([PUSH_XML, VOLUME_XML])
+  with patch.object(api, '_exec_cmd', AsyncMock(side_effect=[PUSH_XML, VOLUME_XML])):
+    result = await api._exec_get_xml('UIC', 'GetVolume', 'VolumeLevel')
+  assert result == {'@result': 'ok', 'volume': '10'}
+
+
+async def test_exec_get_xml_exhausts_retries():
+  """Returns None after all retries are consumed by wrong-method responses."""
+  push_responses = [PUSH_XML] * 3
+  with patch('custom_components.samsung_soundbar.media_player.MultiRoomApi._exec_cmd',
+             AsyncMock(side_effect=push_responses)):
+    api = MultiRoomApi("192.168.1.100", "56001", MagicMock(), None)
+    result = await api._exec_get_xml('UIC', 'GetVolume', 'VolumeLevel', retries=3)
+  assert result is None
+
+
+async def test_exec_get_xml_timeout_passed_through():
+  """The timeout argument is forwarded to _exec_cmd."""
+  api = _make_api(VOLUME_XML)
+  with patch.object(api, '_exec_cmd', AsyncMock(return_value=VOLUME_XML)) as mock_cmd:
+    await api._exec_get_xml('UIC', 'GetVolume', 'VolumeLevel', timeout=0.5)
+  mock_cmd.assert_called_once_with('UIC', '<name>GetVolume</name>', timeout=0.5)
+
+
+# --- existing get_* tests (legacy regex path) ---
+
 async def test_get_speaker_name_plain(hass):
   """get_speaker_name returns the name when it is a plain string."""
   api = _make_api("<UIC><response result='ok'><spkname>Office Soundbar</spkname></response></UIC>")

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from custom_components.samsung_soundbar.media_player import MultiRoomApi
 
-from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.const import CONF_HOST, CONF_NAME, STATE_OFF
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -257,20 +257,11 @@ async def test_get_source_physical_input(hass):
   result = await api.get_source()
   assert result == {'mode': 'hdmi1', 'submode': False}
 
-
-async def test_get_source_bluetooth(hass):
-  """get_source returns {'mode': 'bt', 'submode': False} for Bluetooth (no submode lookup)."""
-  api = _make_api('<UIC><method>CurrentFunc</method><response result="ok"><function>bt</function></response></UIC>')
-  result = await api.get_source()
-  assert result == {'mode': 'bt', 'submode': False}
-
-
 async def test_get_source_wifi_tunein(hass):
   """get_source returns {'mode': 'wifi', 'submode': 'TuneIn'} when submode is 'cp' (streaming)."""
   api = _make_api('<UIC><method>CurrentFunc</method><response result="ok"><function>wifi</function><submode>cp</submode></response></UIC>')
   result = await api.get_source()
   assert result == {'mode': 'wifi', 'submode': 'TuneIn'}
-
 
 async def test_get_source_wifi_other_submode(hass):
   """get_source returns {'mode': 'wifi', 'submode': False} for wifi with a non-cp submode."""
@@ -278,11 +269,12 @@ async def test_get_source_wifi_other_submode(hass):
   result = await api.get_source()
   assert result == {'mode': 'wifi', 'submode': False}
 
-
 async def test_get_source_wifi_on_exhausted_retries():
   """get_source falls back to wifi after all retries return push events instead of CurrentFunc."""
   api = MultiRoomApi("192.168.1.100", "56001", MagicMock(), None)
-  with patch.object(api, '_exec_cmd', AsyncMock(side_effect=[PUSH_XML, PUSH_XML, PUSH_XML])):
+  with patch.object(api, '_exec_cmd', AsyncMock(side_effect=[PUSH_XML, PUSH_XML, PUSH_XML])), \
+       patch('custom_components.samsung_soundbar.media_player.is_airplay_active',
+             new=AsyncMock(return_value=False)):
     result = await api.get_source()
   assert result == {'mode': 'wifi', 'submode': False}
 
@@ -299,9 +291,65 @@ async def test_get_source_retries_past_push_event():
 async def test_get_source_wifi_on_push_then_timeout():
   """get_source falls back to wifi when a push event is followed by a timeout (None)."""
   api = MultiRoomApi("192.168.1.100", "56001", MagicMock(), None)
-  with patch.object(api, '_exec_cmd', AsyncMock(side_effect=[PUSH_XML, None])):
+  with patch.object(api, '_exec_cmd', AsyncMock(side_effect=[PUSH_XML, None])), \
+       patch('custom_components.samsung_soundbar.media_player.is_airplay_active',
+             new=AsyncMock(return_value=False)):
     result = await api.get_source()
   assert result == {'mode': 'wifi', 'submode': False}
+
+
+# --- get_source AirPlay probe ---
+
+async def test_get_source_wifi_fallback_airplay_active():
+  """When GetFunc times out and is_airplay_active returns True, submode is 'AirPlay'."""
+  api = MultiRoomApi("192.168.1.100", "56001", MagicMock(), None)
+  with patch.object(api, '_exec_cmd', AsyncMock(return_value=None)), \
+       patch('custom_components.samsung_soundbar.media_player.is_airplay_active',
+             new=AsyncMock(return_value=True)) as mock_probe:
+    result = await api.get_source()
+  assert result == {'mode': 'wifi', 'submode': 'AirPlay'}
+  mock_probe.assert_called_once_with("192.168.1.100")
+
+
+async def test_get_source_wifi_fallback_airplay_inactive():
+  """When GetFunc times out and is_airplay_active returns False, submode is False."""
+  api = MultiRoomApi("192.168.1.100", "56001", MagicMock(), None)
+  with patch.object(api, '_exec_cmd', AsyncMock(return_value=None)), \
+       patch('custom_components.samsung_soundbar.media_player.is_airplay_active',
+             new=AsyncMock(return_value=False)) as mock_probe:
+    result = await api.get_source()
+  assert result == {'mode': 'wifi', 'submode': False}
+  mock_probe.assert_called_once_with("192.168.1.100")
+
+
+async def test_get_source_physical_input_no_airplay_probe():
+  """Physical input → is_airplay_active is never called."""
+  api = _make_api('<UIC><method>CurrentFunc</method><response result="ok"><function>hdmi1</function><submode></submode></response></UIC>')
+  with patch('custom_components.samsung_soundbar.media_player.is_airplay_active',
+             new=AsyncMock(return_value=True)) as mock_probe:
+    result = await api.get_source()
+  assert result == {'mode': 'hdmi1', 'submode': False}
+  mock_probe.assert_not_called()
+
+
+async def test_get_source_bt_no_airplay_probe():
+  """Bluetooth → is_airplay_active is never called."""
+  api = _make_api('<UIC><method>CurrentFunc</method><response result="ok"><function>bt</function></response></UIC>')
+  with patch('custom_components.samsung_soundbar.media_player.is_airplay_active',
+             new=AsyncMock(return_value=True)) as mock_probe:
+    result = await api.get_source()
+  assert result == {'mode': 'bt', 'submode': False}
+  mock_probe.assert_not_called()
+
+
+async def test_get_source_tunein_no_airplay_probe():
+  """TuneIn (GetFunc returns CurrentFunc) → is_airplay_active is never called."""
+  api = _make_api('<UIC><method>CurrentFunc</method><response result="ok"><function>wifi</function><submode>cp</submode></response></UIC>')
+  with patch('custom_components.samsung_soundbar.media_player.is_airplay_active',
+             new=AsyncMock(return_value=True)) as mock_probe:
+    result = await api.get_source()
+  assert result == {'mode': 'wifi', 'submode': 'TuneIn'}
+  mock_probe.assert_not_called()
 
 
 async def test_yaml_update_scales_volume_from_device_nondefault_max(hass):
@@ -316,3 +364,65 @@ async def test_yaml_update_scales_volume_from_device_nondefault_max(hass):
   await entity.async_update()
 
   assert entity._volume == 0.25
+
+
+# --- _update_with_power_options ---
+
+async def test_update_power_options_airplay_sets_title(hass):
+  """AirPlay mode → _media_title='AirPlay', _image_url=None."""
+  entities = await _setup_entry(hass, BASE_ENTRY_DATA)
+  entity = entities[0]
+  entity.api.get_state = AsyncMock(return_value="1")
+  entity.api.get_source = AsyncMock(return_value={'mode': 'wifi', 'submode': 'AirPlay'})
+  entity.api.get_volume = AsyncMock(return_value="10")
+  entity.api.get_muted = AsyncMock(return_value=False)
+
+  await entity._update_with_power_options()
+
+  assert entity._media_title == 'AirPlay'
+  assert entity._image_url is None
+
+
+async def test_update_power_options_tunein_calls_refresh_media(hass):
+  """TuneIn mode → _refresh_media_info is called; title and image are populated."""
+  entities = await _setup_entry(hass, BASE_ENTRY_DATA)
+  entity = entities[0]
+  entity.api.get_state = AsyncMock(return_value="1")
+  entity.api.get_source = AsyncMock(return_value={'mode': 'wifi', 'submode': 'TuneIn'})
+  entity.api.get_volume = AsyncMock(return_value="10")
+  entity.api.get_muted = AsyncMock(return_value=False)
+  entity.api.get_radio_info = AsyncMock(return_value="Radio Song")
+  entity.api.get_radio_image = AsyncMock(return_value="http://example.com/img.jpg")
+
+  await entity._update_with_power_options()
+
+  assert entity._media_title == 'Radio Song'
+  assert entity._image_url == "http://example.com/img.jpg"
+
+
+async def test_update_power_options_idle_wifi_clears_title(hass):
+  """Idle WiFi mode → _media_title='', _image_url=None."""
+  entities = await _setup_entry(hass, BASE_ENTRY_DATA)
+  entity = entities[0]
+  entity.api.get_state = AsyncMock(return_value="1")
+  entity.api.get_source = AsyncMock(return_value={'mode': 'wifi', 'submode': False})
+  entity.api.get_volume = AsyncMock(return_value="10")
+  entity.api.get_muted = AsyncMock(return_value=False)
+
+  await entity._update_with_power_options()
+
+  assert entity._media_title == ''
+  assert entity._image_url is None
+
+
+async def test_update_power_options_device_off_clears_title(hass):
+  """Device off → state=STATE_OFF, _media_title='', _image_url=None."""
+  entities = await _setup_entry(hass, BASE_ENTRY_DATA)
+  entity = entities[0]
+  entity.api.get_state = AsyncMock(return_value="0")
+
+  await entity._update_with_power_options()
+
+  assert entity._state == STATE_OFF
+  assert entity._media_title == ''
+  assert entity._image_url is None

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -103,7 +103,7 @@ async def test_yaml_update_scales_volume_from_device(hass):
   entity = entities[0]
   entity.api.get_state = AsyncMock(return_value="1")
   entity.api.get_source = AsyncMock(return_value={'mode': 'hdmi1', 'submode': False})
-  entity.api.get_volume = AsyncMock(return_value=["10"])
+  entity.api.get_volume = AsyncMock(return_value="10")
   entity.api.get_muted = AsyncMock(return_value=False)
 
   await entity.async_update()
@@ -193,67 +193,63 @@ async def test_exec_get_xml_timeout_passed_through():
   mock_cmd.assert_called_once_with('UIC', '<name>GetVolume</name>', timeout=0.5)
 
 
-# --- existing get_* tests (legacy regex path) ---
+# --- get_* tests ---
 
-async def test_get_speaker_name_plain(hass):
-  """get_speaker_name returns the name when it is a plain string."""
-  api = _make_api("<UIC><response result='ok'><spkname>Office Soundbar</spkname></response></UIC>")
+async def test_get_speaker_name_plain():
+  """get_speaker_name returns the name as a plain string."""
+  api = _make_api('<UIC><method>SpkName</method><response result="ok"><spkname>Office Soundbar</spkname></response></UIC>')
   result = await api.get_speaker_name()
-  assert result == ["Office Soundbar"]
+  assert result == "Office Soundbar"
 
-async def test_get_speaker_name_cdata(hass):
-  """get_speaker_name strips CDATA wrapper and returns the bare name."""
-  api = _make_api("<UIC><response result='ok'><spkname><![CDATA[Office Soundbar]]></spkname></response></UIC>")
+async def test_get_speaker_name_cdata():
+  """get_speaker_name strips CDATA transparently via xmltodict."""
+  api = _make_api('<UIC><method>SpkName</method><response result="ok"><spkname><![CDATA[Office Soundbar]]></spkname></response></UIC>')
   result = await api.get_speaker_name()
-  assert result == ["Office Soundbar"]
+  assert result == "Office Soundbar"
 
-async def test_get_state_on(hass):
+async def test_get_state_on():
   """get_state returns '1' when the soundbar is powered on."""
-  api = _make_api("<UIC><response result='ok'><powerStatus>1</powerStatus></response></UIC>")
+  api = _make_api('<UIC><method>PowerStatus</method><response result="ok"><powerStatus>1</powerStatus></response></UIC>')
   result = await api.get_state()
   assert result == "1"
 
-async def test_get_volume(hass):
-  """get_volume returns the volume level as a single-element list."""
-  api = _make_api("<UIC><response result='ok'><volume>15</volume></response></UIC>")
+async def test_get_volume():
+  """get_volume returns the volume level as a string."""
+  api = _make_api('<UIC><method>VolumeLevel</method><response result="ok"><volume>15</volume></response></UIC>')
   result = await api.get_volume()
-  assert result == ["15"]
+  assert result == "15"
 
 # --- get_muted ---
-async def test_get_muted_when_muted(hass):
-  """get_muted returns False even when the device reports muted.
-
-  Bug: _exec_get returns a list (e.g. ['on']), which is compared with == to the
-  string BOOL_ON ('on'). A list never equals a string, so this always returns False.
-  """
-  api = _make_api("<UIC><response result='ok'><mute>on</mute></response></UIC>")
+async def test_get_muted_when_muted():
+  """get_muted returns True when the device reports muted."""
+  api = _make_api('<UIC><method>MuteStatus</method><response result="ok"><mute>on</mute></response></UIC>')
   result = await api.get_muted()
-  assert result == False  # noqa: E712 — documenting broken list-vs-string comparison
+  assert result is True
 
-async def test_get_muted_when_unmuted(hass):
+async def test_get_muted_when_unmuted():
   """get_muted returns False when the device reports unmuted."""
-  api = _make_api("<UIC><response result='ok'><mute>off</mute></response></UIC>")
+  api = _make_api('<UIC><method>MuteStatus</method><response result="ok"><mute>off</mute></response></UIC>')
   result = await api.get_muted()
-  assert result == False  # noqa: E712
+  assert result is False
 
 
-async def test_get_radio_info(hass):
-  """get_radio_info returns the title in a single-element list."""
-  api = _make_api("<CPM><response result='ok'><title>My Song</title></response></CPM>")
+async def test_get_radio_info():
+  """get_radio_info returns the title as a string."""
+  api = _make_api('<CPM><method>RadioInfo</method><response result="ok"><title>My Song</title></response></CPM>')
   result = await api.get_radio_info()
-  assert result == ["My Song"]
+  assert result == "My Song"
 
-async def test_get_radio_info_cdata_not_stripped(hass):
-  """get_radio_info does not strip CDATA; the raw markup is returned as-is."""
-  api = _make_api("<CPM><response result='ok'><title><![CDATA[My Song]]></title></response></CPM>")
+async def test_get_radio_info_cdata_stripped():
+  """get_radio_info strips CDATA transparently via xmltodict."""
+  api = _make_api('<CPM><method>RadioInfo</method><response result="ok"><title><![CDATA[My Song]]></title></response></CPM>')
   result = await api.get_radio_info()
-  assert result == ["<![CDATA[My Song]]>"]
+  assert result == "My Song"
 
-async def test_get_radio_image(hass):
-  """get_radio_image returns the thumbnail URL in a single-element list."""
-  api = _make_api("<CPM><response result='ok'><thumbnail>http://example.com/img.jpg</thumbnail></response></CPM>")
+async def test_get_radio_image():
+  """get_radio_image returns the thumbnail URL as a string."""
+  api = _make_api('<CPM><method>RadioInfo</method><response result="ok"><thumbnail>http://example.com/img.jpg</thumbnail></response></CPM>')
   result = await api.get_radio_image()
-  assert result == ["http://example.com/img.jpg"]
+  assert result == "http://example.com/img.jpg"
 
 async def test_get_source_physical_input(hass):
   """get_source returns {'mode': function, 'submode': False} for physical inputs like hdmi1."""
@@ -296,7 +292,7 @@ async def test_yaml_update_scales_volume_from_device_nondefault_max(hass):
   entity = entities[0]
   entity.api.get_state = AsyncMock(return_value="1")
   entity.api.get_source = AsyncMock(return_value={'mode': 'hdmi1', 'submode': False})
-  entity.api.get_volume = AsyncMock(return_value=["15"])
+  entity.api.get_volume = AsyncMock(return_value="15")
   entity.api.get_muted = AsyncMock(return_value=False)
 
   await entity.async_update()

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -102,7 +102,7 @@ async def test_yaml_update_scales_volume_from_device(hass):
   entities = await _setup_platform(hass, BASE_YAML_CONFIG)
   entity = entities[0]
   entity.api.get_state = AsyncMock(return_value="1")
-  entity.api.get_source = AsyncMock(return_value=["hdmi1", False])
+  entity.api.get_source = AsyncMock(return_value={'mode': 'hdmi1', 'submode': False})
   entity.api.get_volume = AsyncMock(return_value=["10"])
   entity.api.get_muted = AsyncMock(return_value=False)
 
@@ -183,31 +183,31 @@ async def test_get_radio_image(hass):
   assert result == ["http://example.com/img.jpg"]
 
 async def test_get_source_physical_input(hass):
-  """get_source returns [function, False] for physical inputs like hdmi1."""
+  """get_source returns {'mode': function, 'submode': False} for physical inputs like hdmi1."""
   api = _make_api('<UIC><response result="ok"><function>hdmi1</function><submode></submode></response></UIC>')
   result = await api.get_source()
-  assert result == ["hdmi1", False]
+  assert result == {'mode': 'hdmi1', 'submode': False}
 
 
 async def test_get_source_bluetooth(hass):
-  """get_source returns ['bt', False] for Bluetooth (no submode lookup)."""
+  """get_source returns {'mode': 'bt', 'submode': False} for Bluetooth (no submode lookup)."""
   api = _make_api('<UIC><response result="ok"><function>bt</function></response></UIC>')
   result = await api.get_source()
-  assert result == ["bt", False]
+  assert result == {'mode': 'bt', 'submode': False}
 
 
 async def test_get_source_wifi_tunein(hass):
-  """get_source returns ['wifi', 'TuneIn'] when submode is 'cp' (streaming)."""
+  """get_source returns {'mode': 'wifi', 'submode': 'TuneIn'} when submode is 'cp' (streaming)."""
   api = _make_api('<UIC><response result="ok"><function>wifi</function><submode>cp</submode></response></UIC>')
   result = await api.get_source()
-  assert result == ["wifi", "TuneIn"]
+  assert result == {'mode': 'wifi', 'submode': 'TuneIn'}
 
 
 async def test_get_source_wifi_other_submode(hass):
-  """get_source returns ['wifi', False] for wifi with a non-cp submode."""
+  """get_source returns {'mode': 'wifi', 'submode': False} for wifi with a non-cp submode."""
   api = _make_api('<UIC><response result="ok"><function>wifi</function><submode>dlna</submode></response></UIC>')
   result = await api.get_source()
-  assert result == ["wifi", False]
+  assert result == {'mode': 'wifi', 'submode': False}
 
 
 async def test_yaml_update_scales_volume_from_device_nondefault_max(hass):
@@ -215,7 +215,7 @@ async def test_yaml_update_scales_volume_from_device_nondefault_max(hass):
   entities = await _setup_platform(hass, {**BASE_YAML_CONFIG, CONF_MAX_VOLUME: "60"})
   entity = entities[0]
   entity.api.get_state = AsyncMock(return_value="1")
-  entity.api.get_source = AsyncMock(return_value=["hdmi1", False])
+  entity.api.get_source = AsyncMock(return_value={'mode': 'hdmi1', 'submode': False})
   entity.api.get_volume = AsyncMock(return_value=["15"])
   entity.api.get_muted = AsyncMock(return_value=False)
 

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -128,12 +128,87 @@ async def test_get_speaker_name_plain(hass):
   result = await api.get_speaker_name()
   assert result == ["Office Soundbar"]
 
-
 async def test_get_speaker_name_cdata(hass):
   """get_speaker_name strips CDATA wrapper and returns the bare name."""
   api = _make_api("<UIC><response result='ok'><spkname><![CDATA[Office Soundbar]]></spkname></response></UIC>")
   result = await api.get_speaker_name()
   assert result == ["Office Soundbar"]
+
+async def test_get_state_on(hass):
+  """get_state returns '1' when the soundbar is powered on."""
+  api = _make_api("<UIC><response result='ok'><powerStatus>1</powerStatus></response></UIC>")
+  result = await api.get_state()
+  assert result == "1"
+
+async def test_get_volume(hass):
+  """get_volume returns the volume level as a single-element list."""
+  api = _make_api("<UIC><response result='ok'><volume>15</volume></response></UIC>")
+  result = await api.get_volume()
+  assert result == ["15"]
+
+# --- get_muted ---
+async def test_get_muted_when_muted(hass):
+  """get_muted returns False even when the device reports muted.
+
+  Bug: _exec_get returns a list (e.g. ['on']), which is compared with == to the
+  string BOOL_ON ('on'). A list never equals a string, so this always returns False.
+  """
+  api = _make_api("<UIC><response result='ok'><mute>on</mute></response></UIC>")
+  result = await api.get_muted()
+  assert result == False  # noqa: E712 — documenting broken list-vs-string comparison
+
+async def test_get_muted_when_unmuted(hass):
+  """get_muted returns False when the device reports unmuted."""
+  api = _make_api("<UIC><response result='ok'><mute>off</mute></response></UIC>")
+  result = await api.get_muted()
+  assert result == False  # noqa: E712
+
+
+async def test_get_radio_info(hass):
+  """get_radio_info returns the title in a single-element list."""
+  api = _make_api("<CPM><response result='ok'><title>My Song</title></response></CPM>")
+  result = await api.get_radio_info()
+  assert result == ["My Song"]
+
+async def test_get_radio_info_cdata_not_stripped(hass):
+  """get_radio_info does not strip CDATA; the raw markup is returned as-is."""
+  api = _make_api("<CPM><response result='ok'><title><![CDATA[My Song]]></title></response></CPM>")
+  result = await api.get_radio_info()
+  assert result == ["<![CDATA[My Song]]>"]
+
+async def test_get_radio_image(hass):
+  """get_radio_image returns the thumbnail URL in a single-element list."""
+  api = _make_api("<CPM><response result='ok'><thumbnail>http://example.com/img.jpg</thumbnail></response></CPM>")
+  result = await api.get_radio_image()
+  assert result == ["http://example.com/img.jpg"]
+
+async def test_get_source_physical_input(hass):
+  """get_source returns [function, False] for physical inputs like hdmi1."""
+  api = _make_api('<UIC><response result="ok"><function>hdmi1</function><submode></submode></response></UIC>')
+  result = await api.get_source()
+  assert result == ["hdmi1", False]
+
+
+async def test_get_source_bluetooth(hass):
+  """get_source returns ['bt', False] for Bluetooth (no submode lookup)."""
+  api = _make_api('<UIC><response result="ok"><function>bt</function></response></UIC>')
+  result = await api.get_source()
+  assert result == ["bt", False]
+
+
+async def test_get_source_wifi_tunein(hass):
+  """get_source returns ['wifi', 'TuneIn'] when submode is 'cp' (streaming)."""
+  api = _make_api('<UIC><response result="ok"><function>wifi</function><submode>cp</submode></response></UIC>')
+  result = await api.get_source()
+  assert result == ["wifi", "TuneIn"]
+
+
+async def test_get_source_wifi_other_submode(hass):
+  """get_source returns ['wifi', False] for wifi with a non-cp submode."""
+  api = _make_api('<UIC><response result="ok"><function>wifi</function><submode>dlna</submode></response></UIC>')
+  result = await api.get_source()
+  assert result == ["wifi", False]
+
 
 async def test_yaml_update_scales_volume_from_device_nondefault_max(hass):
   """async_update scaling works correctly with a non-default max_volume."""

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -184,28 +184,35 @@ async def test_get_radio_image(hass):
 
 async def test_get_source_physical_input(hass):
   """get_source returns {'mode': function, 'submode': False} for physical inputs like hdmi1."""
-  api = _make_api('<UIC><response result="ok"><function>hdmi1</function><submode></submode></response></UIC>')
+  api = _make_api('<UIC><method>CurrentFunc</method><response result="ok"><function>hdmi1</function><submode></submode></response></UIC>')
   result = await api.get_source()
   assert result == {'mode': 'hdmi1', 'submode': False}
 
 
 async def test_get_source_bluetooth(hass):
   """get_source returns {'mode': 'bt', 'submode': False} for Bluetooth (no submode lookup)."""
-  api = _make_api('<UIC><response result="ok"><function>bt</function></response></UIC>')
+  api = _make_api('<UIC><method>CurrentFunc</method><response result="ok"><function>bt</function></response></UIC>')
   result = await api.get_source()
   assert result == {'mode': 'bt', 'submode': False}
 
 
 async def test_get_source_wifi_tunein(hass):
   """get_source returns {'mode': 'wifi', 'submode': 'TuneIn'} when submode is 'cp' (streaming)."""
-  api = _make_api('<UIC><response result="ok"><function>wifi</function><submode>cp</submode></response></UIC>')
+  api = _make_api('<UIC><method>CurrentFunc</method><response result="ok"><function>wifi</function><submode>cp</submode></response></UIC>')
   result = await api.get_source()
   assert result == {'mode': 'wifi', 'submode': 'TuneIn'}
 
 
 async def test_get_source_wifi_other_submode(hass):
   """get_source returns {'mode': 'wifi', 'submode': False} for wifi with a non-cp submode."""
-  api = _make_api('<UIC><response result="ok"><function>wifi</function><submode>dlna</submode></response></UIC>')
+  api = _make_api('<UIC><method>CurrentFunc</method><response result="ok"><function>wifi</function><submode>dlna</submode></response></UIC>')
+  result = await api.get_source()
+  assert result == {'mode': 'wifi', 'submode': False}
+
+
+async def test_get_source_wifi_non_currentfunc_response(hass):
+  """get_source infers wifi when GetFunc returns any non-CurrentFunc response."""
+  api = _make_api('<UIC><method>VolumeLevel</method><version>1.0</version><response result="ok"><volume>10</volume></response></UIC>')
   result = await api.get_source()
   assert result == {'mode': 'wifi', 'submode': False}
 


### PR DESCRIPTION
Building on top of #20, this PR adds an mDNS-probe flow when in Wifi mode that attempts to determine if the source is AirPlay .

AirPlay devices publish an mDNS record that indicates currently playing status, and so if we're in Wifi mode (and not TuneIn), we can try a unicast probe and if the flag is set for AirPlay-now-playing, then set the submode (and thence media title) to AirPlay.

Same AI disclosure as #20: : I used Claude as a development aid for this, but was very opinionated about how to approach each problem and did my best to keep each commit small and human-understandable so that I could review it carefully. I reviewed all generated code, and made a special effort to ensure that there were tests for all the branches I could identify. I also tested pretty extensively against the HW-Q900A I have access to.

This builds on top of #19 and #20 and could be merged on top of them or instead of them (it includes all changes from them).